### PR TITLE
(Feature) Add TfvarsFilesPlugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Added the [TfvarsFilesPlugin](./docs/TfvarsFilesPlugin.md) to support adding var files to plan and apply commands.
+
 # v5.2
 
 * [Issue #168](https://github.com/manheim/terraform-pipeline/issues/168) Fix typo in Jenkinsfile

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The example above gives you a bare-bones pipeline, and there may be Jenkinsfile 
 * [FileParametersPlugin](./docs/FileParametersPlugin.md): Use properties files to inject environment-specific variables.
 * [ParameterStoreBuildWrapperPlugin](./docs/ParameterStoreBuildWrapperPlugin.md): Inject environment-specific variables using `withAwsParameterStore`.
 * [ParameterStoreExecPlugin](./docs/ParameterStoreExecPlugin.md): Inject environment-specific variables using parameter-store-exec.
+* [TfvarsFilesPlugin](./docs/TfvarsFilesPlugin.md): Add environment specific tfvars files to your plan and apply commands.
 ### IAM Role Management
 * [AwssumePlugin](./docs/AwssumePlugin.md): Use the awssume gem to assume different IAM roles.
 * [WithAwsPlugin](./docs/WithAwsPlugin.md): Use `withAws` to assume different IAM roles.

--- a/docs/TfvarsFilesPlugin.md
+++ b/docs/TfvarsFilesPlugin.md
@@ -1,0 +1,38 @@
+## [TfvarsFilesPlugin](../src/TfvarsFilesPlugin.groovy)
+
+This plugin allows you to add `-var-file=${environment}.tfvars` to your plan
+and apply commands.  It supports being configured for a directory relative to
+to the git root. 
+
+For the following repository:
+
+```
+.
+├── Jenkinsfile
+├── main.tf
+├── variables.tf
+└── tfvars
+    ├── qa.tfvars
+    ├── uat.tfvars
+    └── prod.tfvars
+```
+
+```
+// Jenkinsfile
+@Library(['terraform-pipeline@v5.3']) _
+
+Jenkinsfile.init(this)
+
+TfvarsFilesPlugin.withDirectory('./tfvars').init()
+
+def validate = new TerraformValidateStage()
+
+def deployQA = new TerraformEnvironmentStage('qa')
+def deployUat = new TerraformEnvironmentStage('uat')
+def deployProd = new TerraformEnvironmentStage('prod')
+
+validate.then(deployQA)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -4,6 +4,7 @@ class TerraformPlanCommand {
     private String command = "plan"
     String environment
     private prefixes = []
+    private arguments = []
     private static plugins = []
     private appliedPlugins = []
     private String directory
@@ -27,6 +28,11 @@ class TerraformPlanCommand {
         return this
     }
 
+    public TerraformPlanCommand withArgument(String argument) {
+        this.arguments << argument
+        return this
+    }
+
     public String toString() {
         applyPluginsOnce()
 
@@ -37,6 +43,7 @@ class TerraformPlanCommand {
         if (!input) {
             pieces << "-input=false"
         }
+        pieces += arguments
         if (directory) {
             pieces << directory
         }

--- a/src/TfvarsFilesPlugin.groovy
+++ b/src/TfvarsFilesPlugin.groovy
@@ -1,0 +1,38 @@
+class TfvarsFilesPlugin implements TerraformPlanCommandPlugin, TerraformApplyCommandPlugin {
+
+    static String directory = "."
+
+    static withDirectory(String directory) {
+        TfvarsFilesPlugin.directory = directory
+        return this
+    }
+
+    static void init() {
+        def plugin = new TfvarsFilesPlugin()
+
+        TerraformPlanCommand.addPlugin(plugin)
+        TerraformApplyCommand.addPlugin(plugin)
+    }
+
+    private originalContext = Jenkinsfile.instance.original
+
+    @Override
+    void apply(TerraformApplyCommand command) {
+        def environmentVarFile = "${directory}/${command.environment}.tfvars"
+        if(originalContext.fileExists(environmentVarFile)) {
+            command.withArgument("-var-file=${environmentVarFile}")
+        } else {
+            originalContext.echo "${environmentVarFile} does not exist."
+        }
+    }
+
+    @Override
+    void apply(TerraformPlanCommand command) {
+        def environmentVarFile = "${directory}/${command.environment}.tfvars"
+        if(originalContext.fileExists(environmentVarFile)) {
+            command.withArgument("-var-file=${environmentVarFile}")
+        } else {
+            originalContext.echo "${environmentVarFile} does not exist."
+        }
+    }
+}

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -67,6 +67,26 @@ class TerraformPlanCommandTest {
         }
     }
 
+    public class WithArgument {
+        @Test
+        void addsArgument() {
+            def command = new TerraformPlanCommand().withArgument('foo')
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString(" foo"))
+        }
+
+        @Test
+        void isCumulative() {
+            def command = new TerraformPlanCommand().withArgument('foo').withArgument('bar')
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString(" foo"))
+            assertThat(actualCommand, containsString(" bar"))
+        }
+    }
+
+
     public class Plugins {
         @After
         void resetPlugins() {

--- a/test/TfvarsFilesPluginTest.groovy
+++ b/test/TfvarsFilesPluginTest.groovy
@@ -1,0 +1,155 @@
+import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.not
+import static org.junit.Assert.assertThat
+
+@RunWith(HierarchicalContextRunner.class)
+class TfvarsFilesPluginTest {
+
+    static void setupOriginalContext() {
+        Jenkinsfile.instance = new Jenkinsfile()
+        Jenkinsfile.instance.original = new Expando()
+    }
+
+    static void fileWillExist() {
+        setupOriginalContext()
+        Jenkinsfile.instance.original.fileExists = { file -> true }
+    }
+
+    static void fileWillNotExist() {
+        setupOriginalContext()
+        Jenkinsfile.instance.original.fileExists = { file -> false }
+        Jenkinsfile.instance.original.echo = { message -> }
+    }
+
+    static void initPlugin() {
+        TfvarsFilesPlugin.init()
+    }
+
+    static void initWithDir(String directory) {
+        TfvarsFilesPlugin.withDirectory(directory).init()
+    }
+
+    static void reset() {
+        TerraformPlanCommand.resetPlugins()
+        TerraformApplyCommand.resetPlugins()
+        TfvarsFilesPlugin.directory = '.'
+    }
+
+
+    class Init {
+        @After
+        void resetPlugins() {
+            reset()
+        }
+
+        @Test
+        void modifiesTerraformPlanCommand() {
+            setupOriginalContext()
+            initPlugin()
+            Collection actualPlugins = TerraformPlanCommand.getPlugins()
+            assertThat(actualPlugins, hasItem(instanceOf(TfvarsFilesPlugin.class)))
+        }
+
+        @Test
+        void modifiesTerraformApplyCommand() {
+            setupOriginalContext()
+            initPlugin()
+            Collection actualPlugins = TerraformApplyCommand.getPlugins()
+            assertThat(actualPlugins, hasItem(instanceOf(TfvarsFilesPlugin.class)))
+        }
+    }
+
+    class Directory {
+        @After
+        void resetPlugins() {
+            reset()
+        }
+
+        @Test
+        void setsDirectory() {
+            setupOriginalContext()
+            initWithDir('./test/resources')
+            assertThat(TfvarsFilesPlugin.directory, equalTo('./test/resources'))
+        }
+    }
+
+    class ApplyCommand {
+
+        @After
+        void resetPlugins() {
+            reset()
+        }
+
+        @Test
+        void returnsArgumentIfFileExists() {
+            fileWillExist()
+            initPlugin()
+
+            def command = TerraformApplyCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./test.tfvars'))
+        }
+
+        @Test
+        void doesNotAddArgIfFileExists() {
+            fileWillNotExist()
+            initPlugin()
+
+            def command = TerraformApplyCommand.instanceFor('test')
+            assertThat(command.toString(), not(containsString('-var-file')))
+        }
+
+        @Test
+        void respectsDirectorySetting() {
+            fileWillExist()
+            initWithDir('./resources')
+
+            def command = TerraformApplyCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./resources/test.tfvars'))
+        }
+
+        class PlanCommand {
+
+            @After
+            void resetPlugins() {
+                reset()
+            }
+
+            @Test
+            void returnsArgumentIfFileExists() {
+                fileWillExist()
+                initPlugin()
+
+                def command = TerraformPlanCommand.instanceFor('test')
+                assertThat(command.toString(), containsString('-var-file=./test.tfvars'))
+            }
+
+            @Test
+            void doesNotAddArgIfFileExists() {
+                fileWillNotExist()
+                initPlugin()
+
+                def command = TerraformPlanCommand.instanceFor('test')
+                assertThat(command.toString(), not(containsString('-var-file')))
+            }
+
+            @Test
+            void respectsDirectorySetting() {
+                fileWillExist()
+                initWithDir('./resources')
+
+                def command = TerraformPlanCommand.instanceFor('test')
+                assertThat(command.toString(), containsString('-var-file=./resources/test.tfvars'))
+            }
+        }
+    }
+}
+

--- a/test/TfvarsFilesPluginTest.groovy
+++ b/test/TfvarsFilesPluginTest.groovy
@@ -99,7 +99,7 @@ class TfvarsFilesPluginTest {
         }
 
         @Test
-        void doesNotAddArgIfFileExists() {
+        void doesNotAddArgIfFileDoesntExist() {
             fileWillNotExist()
             initPlugin()
 
@@ -133,7 +133,7 @@ class TfvarsFilesPluginTest {
             }
 
             @Test
-            void doesNotAddArgIfFileExists() {
+            void doesNotAddArgIfFileDoesntExists() {
                 fileWillNotExist()
                 initPlugin()
 


### PR DESCRIPTION
This plugin allows you to add environment specific tfvars files to your plan and apply commands.

This required adding the `withArgument('-some-arg')` pattern to the `TerraformPlanCommand` to support this.

Documentation has been added and linked in the Readme.