### PR TITLE
Issue 87 Part 3: Add codenarc and fix terraform-version comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'jacoco'
+apply plugin: 'codenarc'
 
 repositories {
     mavenCentral()

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright 2010 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<ruleset xmlns="http://codenarc.org/ruleset/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
+    <ruleset-ref path='rulesets/groovyism.xml'>
+        <exclude name='GStringExpressionWithinString'/>
+        <exclude name='GetterMethodCouldBeProperty'/>
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/basic.xml'>
+        <exclude name='EmptyClass'/>
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/braces.xml'/>
+    <ruleset-ref path='rulesets/imports.xml'/>
+    <ruleset-ref path='rulesets/formatting.xml'>
+        <exclude name='ClassJavadoc'/>
+        <exclude name='LineLength'/>
+        <exclude name='SpaceAroundMapEntryColon'/>
+    </ruleset-ref>
+</ruleset>

--- a/src/AgentNodePlugin.groovy
+++ b/src/AgentNodePlugin.groovy
@@ -5,7 +5,7 @@ public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformE
     private static String dockerImage
     private static String dockerOptions
 
-    AgentNodePlugin() {}
+    AgentNodePlugin() { }
 
     public static void init() {
         def plugin = new AgentNodePlugin()
@@ -37,7 +37,7 @@ public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformE
     public Closure addAgent() {
         return { closure ->
             if (dockerImage) {
-                docker.image(this.dockerImage).inside(this.dockerOptions){
+                docker.image(this.dockerImage).inside(this.dockerOptions) {
                     closure()
                 }
             } else {

--- a/src/FileParametersPlugin.groovy
+++ b/src/FileParametersPlugin.groovy
@@ -1,6 +1,6 @@
-import groovy.text.StreamingTemplateEngine
-
 import static TerraformEnvironmentStage.ALL
+
+import groovy.text.StreamingTemplateEngine
 
 class FileParametersPlugin implements TerraformEnvironmentStagePlugin {
     public static void init() {

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -44,7 +44,7 @@ class Jenkinsfile {
 
     def Map parseScmUrl(String scmUrl) {
         def matcher = scmUrl =~ /.*(?:\/\/|\@)[^\/:]+[\/:]([^\/]+)\/([^\/.]+)(.git)?/
-        def Map results = new HashMap<String,String>()
+        def Map results = [:]
         results.put("organization", matcher[0][1])
         results.put("repo", matcher[0][2])
         return results
@@ -122,7 +122,6 @@ class Jenkinsfile {
         }
 
         throw new RuntimeException("Your pipeline has ${stages.size()} stages - the maximum supported by default is 7.  Define a custom pipeline template and assign it to Jenkinsfile.pipelineTemplate to create your pipeline.")
-
     }
 
     public getEnv() {

--- a/src/RegressionStage.groovy
+++ b/src/RegressionStage.groovy
@@ -1,7 +1,7 @@
 class RegressionStage implements Stage {
 
     public String testCommand
-    public List automationRepoList = new ArrayList<String>()
+    public List automationRepoList = []
     private String testCommandDirectory
 
     private Closure existingDecorations

--- a/src/S3BackendPlugin.groovy
+++ b/src/S3BackendPlugin.groovy
@@ -20,7 +20,6 @@ class S3BackendPlugin implements TerraformInitCommandPlugin {
         configs['encrypt'] = getEncrypt(environment)
         configs['kms_key_id'] = getKmsKeyId(environment)
 
-
         configs.each { entry ->
             if (entry.value?.trim()) {
                 command.withBackendConfig("${entry.key}=${entry.value}")
@@ -66,12 +65,12 @@ class S3BackendPlugin implements TerraformInitCommandPlugin {
         String region = env['S3_BACKEND_REGION']
 
         if (region == null) {
-           println("No S3_BACKEND_REGION found - checking for environment-specific region")
-           region = env["${environment.toUpperCase()}_S3_BACKEND_REGION"]
+            println("No S3_BACKEND_REGION found - checking for environment-specific region")
+            region = env["${environment.toUpperCase()}_S3_BACKEND_REGION"]
         }
 
         if (region == null) {
-           region = env["${environment}_S3_BACKEND_REGION"]
+            region = env["${environment}_S3_BACKEND_REGION"]
         }
 
         if (region == null) {

--- a/src/SemanticVersion.groovy
+++ b/src/SemanticVersion.groovy
@@ -1,5 +1,3 @@
-import java.util.Comparator;
-
 class SemanticVersion implements Comparable<SemanticVersion> {
 
     private String versionString
@@ -20,26 +18,25 @@ class SemanticVersion implements Comparable<SemanticVersion> {
 
     @Override
     int compareTo(SemanticVersion other) {
-        for(i in 0..<Math.max(this.components.size(), other.components.size())) {
-
-            if(i == this.components.size()) {
+        for (i in 0..<Math.max(this.components.size(), other.components.size())) {
+            if (i == this.components.size()) {
                 return other.components[i].isInteger() ? -1 : 1 //1.0 <=> 1.0.1 : 1.0.1 <=> 1.0.1-rc1
             } else if (i == other.components.size()) {
                 return this.components[i].isInteger() ? 1 : -1 //1.0.1 <=> 1.0 : 1.0.1-rc1 <=> 1.0.1
             }
 
-            if(this.components[i].isInteger() && other.components[i].isInteger()) { //1.0 <=> 1.1 or //1.1 <=> 1.0
+            if (this.components[i].isInteger() && other.components[i].isInteger()) { //1.0 <=> 1.1 or //1.1 <=> 1.0
                 int diff = (this.components[i] as int) <=> (other.components[i] as int)
-                if(diff != 0) {
+                if (diff != 0) {
                     return diff
                 }
-            } else if(this.components[i].isInteger()) { //1.0.3.4 <=> 1.0.3.4b goes to the former. Hmm.
+            } else if (this.components[i].isInteger()) { //1.0.3.4 <=> 1.0.3.4b goes to the former. Hmm.
                 return 1
-            } else if(other.components[i].isInteger()) { //1.0.3.4-rc3 <=> 1.0.3.4 goes to the later.
+            } else if (other.components[i].isInteger()) { //1.0.3.4-rc3 <=> 1.0.3.4 goes to the later.
                 return -1
             } else {
                 int diff = this.components[i] <=> other.components[i] //1.0.3.3 <=> 1.0.3.4 works at least. :-/
-                if(diff != 0) {
+                if (diff != 0) {
                     return diff
                 }
             }

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -54,7 +54,7 @@ class TerraformApplyCommand {
     private applyPluginsOnce() {
         def remainingPlugins = plugins - appliedPlugins
 
-        for(TerraformApplyCommandPlugin plugin in remainingPlugins) {
+        for (TerraformApplyCommandPlugin plugin in remainingPlugins) {
             plugin.apply(this)
             appliedPlugins << plugin
         }

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -18,7 +18,7 @@ class TerraformEnvironmentStage implements Stage {
     TerraformEnvironmentStage(String environment) {
         this.environment = environment
         this.jenkinsfile = Jenkinsfile.instance
-        this.decorations = new HashMap<String,Closure>()
+        this.decorations = [:]
     }
 
     public Stage then(Stage nextStages) {
@@ -106,7 +106,7 @@ class TerraformEnvironmentStage implements Stage {
             }
         }
 
-        decorations.put(stageName,newDecoration)
+        decorations.put(stageName, newDecoration)
     }
 
     private void applyDecorationsAround(String stageName, Closure stageClosure) {
@@ -127,7 +127,7 @@ class TerraformEnvironmentStage implements Stage {
 
     public void applyPlugins() {
         // Apply both global and local plugins, in the correct order
-        for(plugin in getAllPlugins()) {
+        for (plugin in getAllPlugins()) {
             plugin.apply(this)
         }
     }

--- a/src/TerraformInitCommand.groovy
+++ b/src/TerraformInitCommand.groovy
@@ -50,7 +50,7 @@ class TerraformInitCommand {
         if (!input) {
             pieces << "-input=false"
         }
-        if(doBackend) {
+        if (doBackend) {
             backendConfigs.each { config ->
                 pieces << "-backend-config=${config}"
             }
@@ -67,7 +67,7 @@ class TerraformInitCommand {
     private applyPluginsOnce() {
         def remainingPlugins = globalPlugins - appliedPlugins
 
-        for(TerraformInitCommandPlugin plugin in remainingPlugins) {
+        for (TerraformInitCommandPlugin plugin in remainingPlugins) {
             plugin.apply(this)
             appliedPlugins << plugin
         }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -55,7 +55,7 @@ class TerraformPlanCommand {
     private applyPluginsOnce() {
         def remainingPlugins = plugins - appliedPlugins
 
-        for(TerraformPlanCommandPlugin plugin in remainingPlugins) {
+        for (TerraformPlanCommandPlugin plugin in remainingPlugins) {
             plugin.apply(this)
             appliedPlugins << plugin
         }

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -23,7 +23,7 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
     }
 
     public SemanticVersion detectVersion() {
-        if(version == null) {
+        if (version == null) {
             if (fileExists(TERRAFORM_VERSION_FILE)) {
                 version = new SemanticVersion(readFile(TERRAFORM_VERSION_FILE))
             } else {
@@ -35,7 +35,7 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
     }
 
     public TerraformPluginVersion strategyFor(String version) {
-        if(new SemanticVersion(version).compareTo(new SemanticVersion('0.12.0')) >= 0) {
+        if (new SemanticVersion(version) >= new SemanticVersion('0.12.0')) {
             return new TerraformPluginVersion12()
         }
 

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -35,7 +35,10 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
     }
 
     public TerraformPluginVersion strategyFor(String version) {
-        if (new SemanticVersion(version) >= new SemanticVersion('0.12.0')) {
+        // if (new SemanticVersion(version) >= new SemanticVersion('0.12.0')) should be used
+        // here.  Unit tests pass with the above, but running Jenkinsfile in a pipeline context
+        // does not.  Debug statements show that the above will return 0 when it should return 'true'.
+        if ((new SemanticVersion(version) <=> new SemanticVersion('0.12.0')) >= 0) {
             return new TerraformPluginVersion12()
         }
 

--- a/src/TerraformValidateCommand.groovy
+++ b/src/TerraformValidateCommand.groovy
@@ -31,8 +31,7 @@ class TerraformValidateCommand {
         pieces = pieces + prefixes
         pieces << terraformBinary
         pieces << command
-        for(String argument in arguments)
-        {
+        for (String argument in arguments) {
             pieces << argument
         }
         if (directory) {
@@ -44,7 +43,7 @@ class TerraformValidateCommand {
     private applyPluginsOnce() {
         def remainingPlugins = globalPlugins - appliedPlugins
 
-        for(TerraformValidateCommandPlugin plugin in remainingPlugins) {
+        for (TerraformValidateCommandPlugin plugin in remainingPlugins) {
             plugin.apply(this)
             appliedPlugins << plugin
         }

--- a/src/TerraformValidateStage.groovy
+++ b/src/TerraformValidateStage.groovy
@@ -9,7 +9,7 @@ class TerraformValidateStage implements Stage {
 
     public TerraformValidateStage() {
         this.jenkinsfile = Jenkinsfile.instance
-        this.decorations = new HashMap<String,Closure>()
+        this.decorations = [:]
     }
 
     public Stage then(Stage nextStage) {
@@ -60,7 +60,7 @@ class TerraformValidateStage implements Stage {
             }
         }
 
-        decorations.put(stageName,newDecoration)
+        decorations.put(stageName, newDecoration)
     }
 
     private void applyDecorationsAround(String stageName, Closure stageClosure) {
@@ -76,7 +76,7 @@ class TerraformValidateStage implements Stage {
     }
 
     public void applyPlugins() {
-        for(plugin in globalPlugins) {
+        for (plugin in globalPlugins) {
             plugin.apply(this)
         }
     }

--- a/src/TfvarsFilesPlugin.groovy
+++ b/src/TfvarsFilesPlugin.groovy
@@ -19,7 +19,7 @@ class TfvarsFilesPlugin implements TerraformPlanCommandPlugin, TerraformApplyCom
     @Override
     void apply(TerraformApplyCommand command) {
         def environmentVarFile = "${directory}/${command.environment}.tfvars"
-        if(originalContext.fileExists(environmentVarFile)) {
+        if (originalContext.fileExists(environmentVarFile)) {
             command.withArgument("-var-file=${environmentVarFile}")
         } else {
             originalContext.echo "${environmentVarFile} does not exist."
@@ -29,7 +29,7 @@ class TfvarsFilesPlugin implements TerraformPlanCommandPlugin, TerraformApplyCom
     @Override
     void apply(TerraformPlanCommand command) {
         def environmentVarFile = "${directory}/${command.environment}.tfvars"
-        if(originalContext.fileExists(environmentVarFile)) {
+        if (originalContext.fileExists(environmentVarFile)) {
             command.withArgument("-var-file=${environmentVarFile}")
         } else {
             originalContext.echo "${environmentVarFile} does not exist."

--- a/test/AnsiColorPluginTest.groovy
+++ b/test/AnsiColorPluginTest.groovy
@@ -1,9 +1,11 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertThat
 
-import org.junit.*
+import org.junit.Test
+import org.junit.After
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class AnsiColorPluginTest {

--- a/test/AwssumePluginTest.groovy
+++ b/test/AwssumePluginTest.groovy
@@ -1,11 +1,17 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.not
+import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
-import static org.hamcrest.Matchers.*
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class AwssumePluginTest {

--- a/test/BuildGraphTest.groovy
+++ b/test/BuildGraphTest.groovy
@@ -1,11 +1,12 @@
-import static org.junit.Assert.*
+import static org.mockito.Mockito.inOrder
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
 
-import org.junit.*
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
 import org.mockito.InOrder
-import static org.mockito.Mockito.*
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class BuildGraphTest {

--- a/test/BuildStageTest.groovy
+++ b/test/BuildStageTest.groovy
@@ -1,11 +1,9 @@
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.mockito.Mockito.verify
-import static org.mockito.Mockito.when
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.doReturn
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class BuildStageTest {
@@ -15,7 +13,7 @@ class BuildStageTest {
         void buildsWithoutError() {
             BuildStage stage = spy(new BuildStage())
 
-            doReturn({ -> }).when(stage).pipelineConfiguration()
+            doReturn { -> }.when(stage).pipelineConfiguration()
 
             stage.build()
         }

--- a/test/ConditionalApplyPluginTest.groovy
+++ b/test/ConditionalApplyPluginTest.groovy
@@ -1,13 +1,15 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Matchers.*
+
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class ConditionalApplyPluginTest {

--- a/test/ConfirmApplyPluginTest.groovy
+++ b/test/ConfirmApplyPluginTest.groovy
@@ -1,9 +1,13 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class ConfirmApplyPluginTest {

--- a/test/ConsulBackendPluginTest.groovy
+++ b/test/ConsulBackendPluginTest.groovy
@@ -1,11 +1,16 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.not
+import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
-import static org.hamcrest.Matchers.*
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class ConsulBackendPluginTest {

--- a/test/CredentialsPluginTest.groovy
+++ b/test/CredentialsPluginTest.groovy
@@ -1,9 +1,15 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.hasSize
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.notNullValue
+import static org.junit.Assert.assertThat
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class CredentialsPluginTest {

--- a/test/CrqPluginTest.groovy
+++ b/test/CrqPluginTest.groovy
@@ -1,14 +1,16 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.is
+import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Matchers.*
-import static org.hamcrest.Matchers.*
-import static org.mockito.Mockito.*;
 
 @RunWith(HierarchicalContextRunner.class)
 class CrqPluginTest {

--- a/test/DefaultEnvironmentPluginTest.groovy
+++ b/test/DefaultEnvironmentPluginTest.groovy
@@ -1,9 +1,10 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertThat
 
-import org.junit.*
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class DefaultEnvironmentPluginTest {

--- a/test/FileParametersPluginTest.groovy
+++ b/test/FileParametersPluginTest.groovy
@@ -1,12 +1,14 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class FileParametersPluginTest {

--- a/test/JenkinsfileTest.groovy
+++ b/test/JenkinsfileTest.groovy
@@ -1,14 +1,12 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-import Jenkinsfile
-
+import static org.junit.Assert.assertEquals
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.hamcrest.Matchers.*
 
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class JenkinsfileTest {

--- a/test/ParameterStoreBuildWrapperPluginTest.groovy
+++ b/test/ParameterStoreBuildWrapperPluginTest.groovy
@@ -1,11 +1,14 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.hamcrest.Matchers.*
+
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class ParameterStoreBuildWrapperPluginTest {

--- a/test/ParameterStoreExecPluginTest.groovy
+++ b/test/ParameterStoreExecPluginTest.groovy
@@ -1,11 +1,15 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
-import static org.hamcrest.Matchers.*
+
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class ParameterStoreExecPluginTest {

--- a/test/RegressionStageTest.groovy
+++ b/test/RegressionStageTest.groovy
@@ -1,10 +1,11 @@
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
+
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class RegressionStageTest {
@@ -23,7 +24,7 @@ class RegressionStageTest {
         }
 
         @Test
-        void automationRepoSpecifiedSuccessfullyCallApply(){
+        void automationRepoSpecifiedSuccessfullyCallApply() {
             RegressionStagePlugin fakePlugin = mock(RegressionStagePlugin.class)
             RegressionStage.addPlugin(fakePlugin)
 
@@ -35,7 +36,7 @@ class RegressionStageTest {
         }
 
         @Test
-        void automationRepoAndAppRepoSpecifiedSuccessfullyCallApply(){
+        void automationRepoAndAppRepoSpecifiedSuccessfullyCallApply() {
             RegressionStagePlugin fakePlugin = mock(RegressionStagePlugin.class)
             RegressionStage.addPlugin(fakePlugin)
 
@@ -48,7 +49,7 @@ class RegressionStageTest {
         }
 
         @Test
-        void automationRepoAndAppRepoWithChangeDirectorySpecifiedSuccessfullyCallApply(){
+        void automationRepoAndAppRepoWithChangeDirectorySpecifiedSuccessfullyCallApply() {
             RegressionStagePlugin fakePlugin = mock(RegressionStagePlugin.class)
             RegressionStage.addPlugin(fakePlugin)
 
@@ -62,7 +63,7 @@ class RegressionStageTest {
         }
 
         @Test
-        void noAutomationRepoSpecifiedSuccessfullyCallApply(){
+        void noAutomationRepoSpecifiedSuccessfullyCallApply() {
             RegressionStagePlugin fakePlugin = mock(RegressionStagePlugin.class)
             RegressionStage.addPlugin(fakePlugin)
 

--- a/test/S3BackendPluginTest.groovy
+++ b/test/S3BackendPluginTest.groovy
@@ -1,12 +1,16 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.contains
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.not
+import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class S3BackendPluginTest {

--- a/test/SemanticVersionTest.groovy
+++ b/test/SemanticVersionTest.groovy
@@ -1,8 +1,8 @@
+import static org.junit.Assert.assertEquals
+
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import static org.junit.Assert.*
-
 
 @RunWith(Parameterized.class)
 class SemanticVersionTest {
@@ -16,10 +16,14 @@ class SemanticVersionTest {
 
     @Test
     void sortsCorrectly() {
-        List<SemanticVersion> unsorted = SORTED.clone().collect({v -> new SemanticVersion(v)})
-        Collections.shuffle(unsorted)
-        def result = unsorted.sort().collect({sv -> sv.version})
-        assertEquals(SORTED,result)
+        List<SemanticVersion> versions = SORTED.clone().collect { v -> new SemanticVersion(v) }
+        // Randomize
+        Collections.shuffle(versions)
+        // Then sort
+        versions.sort()
+
+        def result = versions.collect { sv -> sv.version }
+        assertEquals(SORTED, result)
     }
 
     static SORTED = [
@@ -30,22 +34,22 @@ class SemanticVersionTest {
             '0.1.0.2',
             '0.1.0.10',
             '0.1.0.23',
-            '0.2', 
-            '0.2.0.3.1', 
+            '0.2',
+            '0.2.0.3.1',
             '0.2.0.4',
-            '1.0RC1', 
-            '1.0RC2', 
-            '1.0', 
-            '1.0.1.2', 
-            '1.0.2', 
+            '1.0RC1',
+            '1.0RC2',
+            '1.0',
+            '1.0.1.2',
+            '1.0.2',
             '1.2.2.3',
-            '1.2.3', 
-            '1.5.2_04', 
-            '1.5.2_05', 
-            '1.5.2_10', 
+            '1.2.3',
+            '1.5.2_04',
+            '1.5.2_05',
+            '1.5.2_10',
             '1.6.0_01',
-            '2.0', 
-            '2.0.0_02', 
+            '2.0',
+            '2.0.0_02',
             '3.1'
     ]
 }

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -1,14 +1,16 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.not
+import static org.hamcrest.Matchers.startsWith
+import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformApplyCommandTest {

--- a/test/TerraformDirectoryPluginTest.groovy
+++ b/test/TerraformDirectoryPluginTest.groovy
@@ -1,11 +1,12 @@
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertThat
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformDirectoryPluginTest {

--- a/test/TerraformEnvironmentStageTest.groovy
+++ b/test/TerraformEnvironmentStageTest.groovy
@@ -1,12 +1,16 @@
-import static org.junit.Assert.*
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.isA
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 
-import org.junit.*
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.hamcrest.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformEnvironmentStageTest {
@@ -60,7 +64,16 @@ class TerraformEnvironmentStageTest {
 
         @Test
         void doesNotAddPluginToOtherInstances() {
+            def modifiedStage = new TerraformEnvironmentStage('modified')
+            def unmodifiedStage = new TerraformEnvironmentStage('unmodified')
 
+            def pluginsBefore = unmodifiedStage.getAllPlugins()
+
+            modifiedStage.withEnv('somekey', 'somevalue')
+
+            def pluginsAfter = unmodifiedStage.getAllPlugins()
+
+            assertEquals(pluginsBefore, pluginsAfter)
         }
 
         @Test

--- a/test/TerraformInitCommandTest.groovy
+++ b/test/TerraformInitCommandTest.groovy
@@ -1,14 +1,15 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.not
+import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformInitCommandTest {

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -1,14 +1,16 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.not
+import static org.hamcrest.Matchers.startsWith
+import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformPlanCommandTest {
@@ -85,7 +87,6 @@ class TerraformPlanCommandTest {
             assertThat(actualCommand, containsString(" bar"))
         }
     }
-
 
     public class Plugins {
         @After

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -1,15 +1,13 @@
-import org.junit.*
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.doReturn;
+
+import org.junit.After
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
-import static org.junit.Assert.*
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformPluginTest {

--- a/test/TerraformPluginVersion11Test.groovy
+++ b/test/TerraformPluginVersion11Test.groovy
@@ -1,14 +1,9 @@
-import org.junit.*
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
-import static org.junit.Assert.*
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformPluginVersion11Test {

--- a/test/TerraformPluginVersion12Test.groovy
+++ b/test/TerraformPluginVersion12Test.groovy
@@ -1,14 +1,13 @@
-import org.junit.*
+import static org.hamcrest.Matchers.containsString
+import static org.junit.Assert.assertThat
+import static org.mockito.Matchers.any
+import static org.mockito.Matchers.eq
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
-import static org.junit.Assert.*
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Matchers.*
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformPluginVersion12Test {

--- a/test/TerraformValidateCommandTest.groovy
+++ b/test/TerraformValidateCommandTest.groovy
@@ -1,14 +1,14 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-
-import static org.hamcrest.Matchers.*
+import static org.junit.Assert.assertThat
+import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.startsWith
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformValidateCommandTest {

--- a/test/TfvarsFilesPluginTest.groovy
+++ b/test/TfvarsFilesPluginTest.groovy
@@ -1,15 +1,14 @@
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.not
 import static org.junit.Assert.assertThat
+
+import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
 
 @RunWith(HierarchicalContextRunner.class)
 class TfvarsFilesPluginTest {
@@ -43,7 +42,6 @@ class TfvarsFilesPluginTest {
         TerraformApplyCommand.resetPlugins()
         TfvarsFilesPlugin.directory = '.'
     }
-
 
     class Init {
         @After

--- a/test/WithAwsPluginTest.groovy
+++ b/test/WithAwsPluginTest.groovy
@@ -1,11 +1,15 @@
-import static org.junit.Assert.*
-
-import org.junit.*
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.is
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
-import static org.hamcrest.Matchers.*
+
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class WithAwsPluginTest {
@@ -139,5 +143,4 @@ class WithAwsPluginTest {
         }
     }
 }
-
 


### PR DESCRIPTION
* The initial merge of issue_87_part_3 introduced a regression, when refactoring version comparison to use `>=`.
* The compareTo method of SemanticVersion doesn't properly override the various comparison operators.  It also behaves differently in unit tests than it does under a normal Jenkinsfile context.
* Switch to `<=>` operator instead of `>=` when comparing semantic versions, to determine whether or not to use Terraform v0.12 workflow.

* Test: `new SemanticVersion('0.12.0') >= new SemanticVersion('0.12.0')`
* Expected: `true`
* Actual: `0`