### PR TITLE
Issue 186: convenience method to detect terraform version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * [Issue #87](https://github.com/manheim/terraform-pipeline/issues/87) Add travis CI support to the project
+* [Issue #186](https://github.com/manheim/terraform-pipeline/issues/186) Add convenience method to detect the version of terraform
 
 # v5.3
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  require_ci_to_pass: no

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -88,7 +88,7 @@ class Jenkinsfile {
         return defaultNodeName ?: instance.getEnv().DEFAULT_NODE_NAME
     }
 
-    public static void build(Closure closure) {
+    public static build(Closure closure) {
         closure.delegate = this.instance
         closure.call()
     }

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -34,6 +34,25 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
         return version
     }
 
+    public static String checkVersion() {
+        return Jenkinsfile.build(pipelineConfiguration())
+    }
+
+    private static Closure pipelineConfiguration() {
+        def closure = {
+            node {
+                deleteDir()
+                checkout(scm)
+                def plugin = new TerraformPlugin()
+
+                return plugin.detectVersion()
+            }
+        }
+
+        closure.resolveStrategy = Closure.DELEGATE_ONLY
+        return closure
+    }
+
     public TerraformPluginVersion strategyFor(String version) {
         // if (new SemanticVersion(version) >= new SemanticVersion('0.12.0')) should be used
         // here.  Unit tests pass with the above, but running Jenkinsfile in a pipeline context

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -11,7 +11,7 @@
  */
 class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValidateStagePlugin {
 
-    static SemanticVersion version
+    static String version
     static final String DEFAULT_VERSION = '0.11.0'
     public static TERRAFORM_VERSION_FILE = '.terraform-version'
 
@@ -22,12 +22,12 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
         TerraformValidateStage.addPlugin(plugin)
     }
 
-    public SemanticVersion detectVersion() {
+    public String detectVersion() {
         if (version == null) {
             if (fileExists(TERRAFORM_VERSION_FILE)) {
-                version = new SemanticVersion(readFile(TERRAFORM_VERSION_FILE))
+                version = readFile(TERRAFORM_VERSION_FILE)
             } else {
-                version = new SemanticVersion(DEFAULT_VERSION)
+                version = DEFAULT_VERSION
             }
         }
 
@@ -45,8 +45,8 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
         return new TerraformPluginVersion11()
     }
 
-    static void withVersion(String version) {
-        this.version = new SemanticVersion(version)
+    static void withVersion(String userVersion) {
+        this.version = userVersion
     }
 
     static  void resetVersion() {
@@ -65,7 +65,7 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
     void apply(TerraformValidateCommand command) {
         def version = detectVersion()
 
-        def strategy = strategyFor(version.version)
+        def strategy = strategyFor(version)
         strategy.apply(command)
     }
 
@@ -78,7 +78,7 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
         return { closure ->
             def version = detectVersion()
 
-            def strategy = strategyFor(version.version)
+            def strategy = strategyFor(version)
             strategy.apply(validateStage)
 
             closure()

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -25,7 +25,7 @@ class TerraformPluginTest {
 
             def foundVersion = plugin.detectVersion()
 
-            assertEquals(TerraformPlugin.DEFAULT_VERSION, foundVersion.version)
+            assertEquals(TerraformPlugin.DEFAULT_VERSION, foundVersion)
         }
 
         @Test
@@ -37,7 +37,7 @@ class TerraformPluginTest {
 
             def foundVersion = plugin.detectVersion()
 
-            assertEquals(expectedVersion, foundVersion.version)
+            assertEquals(expectedVersion, foundVersion)
         }
     }
 
@@ -50,7 +50,7 @@ class TerraformPluginTest {
         @Test
         void usesVersionEvenIfFileExists() {
             TerraformPlugin.withVersion('2.0.0')
-            assertEquals('2.0.0', TerraformPlugin.version.version)
+            assertEquals('2.0.0', TerraformPlugin.version)
         }
     }
 


### PR DESCRIPTION
* Issue #186 
* UseCase: I want to use the `agent` block to pull a docker image that contains the terraform executable that matches my project's version.  Allow me to conveniently detect the terraform version so that I pull the correct docker image.

* Example: 
```
Jenkinsfile.init(this)

def terraformVersion = TerraformPlugin.checkVersion()
AgentNodePlugin.withAgentDockerImage("hashicorp/terraform:${terraformVersion}")
               .withAgentDockerImageOptions("--entrypoint=''")
               .init()
...
```