### PR TITLE
Issue 196: Fix defect - Excessive nested closures in Jenkinsfile.init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
+* [Issue #196](https://github.com/manheim/terraform-pipeline/issues/196) Fix defect - Excessive nested closures in Jenkinsfile.init.  Drop support for deprecated `Jenkinsfile.init(this,env)`
 
 # v5.4
 

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -65,15 +65,6 @@ class Jenkinsfile {
     }
 
     def static void init(original, Class customizations=null) {
-        sharedInit(original, customizations)
-    }
-
-    // Deprecate this, env should come from original
-    def static void init(original, env, Class customizations=null) {
-        sharedInit(original, customizations)
-    }
-
-    def static private void sharedInit(original, Class customizations=null) {
         this.original = original
         this.docker   = original.docker
 

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -65,6 +65,15 @@ class Jenkinsfile {
     }
 
     def static void init(original, Class customizations=null) {
+        sharedInit(original, customizations)
+    }
+
+    // Deprecate this, env should come from original
+    def static void init(original, env, Class customizations=null) {
+        sharedInit(original, customizations)
+    }
+
+    def static private void sharedInit(original, Class customizations=null) {
         this.original = original
         this.docker   = original.docker
 
@@ -73,11 +82,6 @@ class Jenkinsfile {
         if (customizations != null) {
             customizations.init()
         }
-    }
-
-    // Deprecate this, env should come from original
-    def static void init(original, env, Class customizations=null) {
-        init(original, customizations)
     }
 
     def static void initializeDefaultPlugins() {


### PR DESCRIPTION
* Newer versions of  "Pipeline: Groovy" confuse the multiple `Jenkinsfile.init` methods.
* The `Jenkinsfile.init(this,env)` method is deprecated - drop support  for this method to solve the  problem.
* Anyone using the deprecated `Jenkinsfile.init(this,env)` method should simply  stop passing the `env` parameter