### PR TITLE
Issue 151 - Fix CPS mismatch errors, reduce meta magic in Jenkinsfile.groovy and Stage decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* [Issue #151](https://github.com/manheim/terraform-pipeline/issues/151) Fix CPS mismatch errors, reduce meta magic in Jenkinsfile.groovy
+* [Issue #151](https://github.com/manheim/terraform-pipeline/issues/151) Fix CPS mismatch errors, reduce meta magic in Jenkinsfile.groovy and Stage decorations
 * [Issue #194](https://github.com/manheim/terraform-pipeline/issues/194) Add support global tfvars files.
 * [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
 * [Issue #196](https://github.com/manheim/terraform-pipeline/issues/196) Fix defect - Excessive nested closures in Jenkinsfile.init.  Drop support for deprecated `Jenkinsfile.init(this,env)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #151](https://github.com/manheim/terraform-pipeline/issues/151) Fix CPS mismatch errors, reduce meta magic in Jenkinsfile.groovy
 * [Issue #194](https://github.com/manheim/terraform-pipeline/issues/194) Add support global tfvars files.
 * [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
 * [Issue #196](https://github.com/manheim/terraform-pipeline/issues/196) Fix defect - Excessive nested closures in Jenkinsfile.init.  Drop support for deprecated `Jenkinsfile.init(this,env)`

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -7,6 +7,7 @@ class BuildStage implements Stage, TerraformEnvironmentStagePlugin {
 
     private String artifactIncludePattern
     private Closure existingDecorations
+    private Jenkinsfile jenkinsfile
 
     private static plugins = []
 
@@ -16,6 +17,7 @@ class BuildStage implements Stage, TerraformEnvironmentStagePlugin {
 
     public BuildStage(String buildCommand) {
         this.buildCommand = buildCommand
+        this.jenkinsfile = Jenkinsfile.instance
     }
 
     public BuildStage saveArtifact(String artifactIncludePattern) {
@@ -48,7 +50,7 @@ class BuildStage implements Stage, TerraformEnvironmentStagePlugin {
         applyPlugins()
 
         return {
-            node {
+            node(jenkinsfile.getNodeName()) {
                 stage("build") {
                     applyDecorations(delegate) {
                         checkout(scm)

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -19,10 +19,6 @@ class Jenkinsfile {
         }
     }
 
-    def invokeMethod(String name, args) {
-        original.invokeMethod(name, args)
-    }
-
     def String getStandardizedRepoSlug() {
         if (repoSlug != null) {
             return repoSlug

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -7,18 +7,6 @@ class Jenkinsfile {
     public static declarative = false
     public static pipelineTemplate
 
-    def node(Closure closure) {
-        closure.delegate = original
-        String label = getNodeName()
-        if (label != null) {
-            echo "Using node: ${label}"
-            original.node(label, closure)
-        } else {
-            echo "defaultNodeName and DEFAULT_NODE_NAME environment variable are null"
-            original.node(closure)
-        }
-    }
-
     def String getStandardizedRepoSlug() {
         if (repoSlug != null) {
             return repoSlug

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -84,8 +84,7 @@ class Jenkinsfile {
     }
 
     public static build(Closure closure) {
-        closure.delegate = this.instance
-        closure.call()
+        original.ApplyJenkinsfileClosure(closure)
     }
 
     public static void build(List<Stage> stages) {

--- a/src/RegressionStage.groovy
+++ b/src/RegressionStage.groovy
@@ -3,6 +3,7 @@ class RegressionStage implements Stage {
     public String testCommand
     public List automationRepoList = []
     private String testCommandDirectory
+    private Jenkinsfile jenkinsfile
 
     private Closure existingDecorations
 
@@ -14,6 +15,7 @@ class RegressionStage implements Stage {
 
     public RegressionStage(String testCommand) {
         this.testCommand = testCommand
+        this.jenkinsfile = Jenkinsfile.instance
     }
 
     public RegressionStage withScm(String automationRepo) {
@@ -38,7 +40,7 @@ class RegressionStage implements Stage {
         applyPlugins()
 
         return {
-            node {
+            node(jenkinsfile.getNodeName()) {
                 stage("test") {
                     applyDecorations(delegate) {
                         if (automationRepoList.isEmpty()) {

--- a/src/StageDecorations.groovy
+++ b/src/StageDecorations.groovy
@@ -2,19 +2,18 @@ class StageDecorations {
     private Map<String,Closure> decorations = [:]
 
     public apply(String group = null, Closure innerClosure) {
-        def currentDecorations = decorations.get(group)
-
-        if (currentDecorations != null) {
-            currentDecorations(innerClosure)
-        } else {
-            innerClosure()
-        }
+        def currentDecorations = decorations.get(group) ?: { stage -> stage() }
+        currentDecorations.delegate = innerClosure.owner
+        currentDecorations(innerClosure)
     }
 
     public add(String group = null, Closure decoration) {
         def existingDecoration = decorations.get(group) ?: { stage -> stage() }
         def newDecoration = { stage ->
+            decoration.delegate = delegate
             decoration() {
+                stage.delegate = delegate
+                existingDecoration.delegate = delegate
                 existingDecoration(stage)
             }
         }

--- a/src/StageDecorations.groovy
+++ b/src/StageDecorations.groovy
@@ -1,0 +1,24 @@
+class StageDecorations {
+    private Map<String,Closure> decorations = [:]
+
+    public apply(String group = null, Closure innerClosure) {
+        def currentDecorations = decorations.get(group)
+
+        if (currentDecorations != null) {
+            currentDecorations(innerClosure)
+        } else {
+            innerClosure()
+        }
+    }
+
+    public add(String group = null, Closure decoration) {
+        def existingDecoration = decorations.get(group) ?: { stage -> stage() }
+        def newDecoration = { stage ->
+            decoration() {
+                existingDecoration(stage)
+            }
+        }
+
+        decorations.put(group, newDecoration)
+    }
+}

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -90,7 +90,6 @@ class TerraformEnvironmentStage implements Stage {
 
     private void applyDecorations(String stageName, Closure stageClosure) {
         def stageDecorations = decorations.get(stageName) ?: { stage -> stage() }
-        stageDecorations.delegate = jenkinsfile
         stageDecorations(stageClosure)
     }
 

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -90,6 +90,7 @@ class TerraformEnvironmentStage implements Stage {
 
     private void applyDecorations(String stageName, Closure stageClosure) {
         def stageDecorations = decorations.get(stageName) ?: { stage -> stage() }
+        stageDecorations.delegate = stageClosure.owner.delegate
         stageDecorations(stageClosure)
     }
 

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -55,7 +55,7 @@ class TerraformEnvironmentStage implements Stage {
 
         def String environment = this.environment
         return { ->
-            node {
+            node(jenkinsfile.getNodeName()) {
                 deleteDir()
                 checkout(scm)
 

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -1,7 +1,7 @@
 class TerraformEnvironmentStage implements Stage {
     private Jenkinsfile jenkinsfile
     private String environment
-    private Map<String,Closure> decorations
+    private StageDecorations decorations
     private TerraformInitCommand initCommand
     private TerraformPlanCommand planCommand
     private TerraformApplyCommand applyCommand
@@ -18,7 +18,7 @@ class TerraformEnvironmentStage implements Stage {
     TerraformEnvironmentStage(String environment) {
         this.environment = environment
         this.jenkinsfile = Jenkinsfile.instance
-        this.decorations = [:]
+        this.decorations = new StageDecorations()
     }
 
     public Stage then(Stage nextStage) {
@@ -59,25 +59,25 @@ class TerraformEnvironmentStage implements Stage {
                 deleteDir()
                 checkout(scm)
 
-                applyDecorations(ALL) {
+                decorations.apply(ALL) {
                     stage("${PLAN}-${environment}") {
-                        applyDecorations(PLAN) {
+                        decorations.apply(PLAN) {
                             sh initCommand.toString()
                             sh planCommand.toString()
                         }
                     }
 
-                    applyDecorationsAround(CONFIRM) {
+                    decorations.apply("Around-${CONFIRM}") {
                         stage("${CONFIRM}-${environment}") {
-                            applyDecorations(CONFIRM) {
+                            decorations.apply(CONFIRM) {
                                 echo "Approved"
                             }
                         }
                     }
 
-                    applyDecorationsAround(APPLY) {
+                    decorations.apply("Around-${APPLY}") {
                         stage("${APPLY}-${environment}") {
-                            applyDecorations(APPLY) {
+                            decorations.apply(APPLY) {
                                 sh initCommand.toString()
                                 sh applyCommand.toString()
                             }
@@ -88,33 +88,12 @@ class TerraformEnvironmentStage implements Stage {
         }
     }
 
-    private void applyDecorations(String stageName, Closure stageClosure) {
-        def stageDecorations = decorations.get(stageName) ?: { stage -> stage() }
-        stageDecorations.delegate = stageClosure.owner.delegate
-        stageDecorations(stageClosure)
-    }
-
     public decorate(String stageName, Closure decoration) {
-        def existingDecorations = decorations.get(stageName) ?: { stage -> stage() }
-        def newDecoration = { stage ->
-            decoration.delegate = delegate
-            decoration.resolveStrategy = Closure.DELEGATE_FIRST
-            decoration() {
-                stage.delegate = delegate
-                existingDecorations.delegate = delegate
-                existingDecorations(stage)
-            }
-        }
-
-        decorations.put(stageName, newDecoration)
-    }
-
-    private void applyDecorationsAround(String stageName, Closure stageClosure) {
-        applyDecorations("Around-${stageName}", stageClosure)
+        decorations.add(stageName, decoration)
     }
 
     public decorateAround(String stageName, Closure decoration) {
-        decorate("Around-${stageName}", decoration)
+        decorations.add("Around-${stageName}", decoration)
     }
 
     public String toString() {

--- a/src/TerraformValidateStage.groovy
+++ b/src/TerraformValidateStage.groovy
@@ -26,7 +26,7 @@ class TerraformValidateStage implements Stage {
         def validateCommand = TerraformValidateCommand.instance()
 
         return {
-            node {
+            node(jenkinsfile.getNodeName()) {
                 deleteDir()
                 checkout(scm)
 

--- a/test/BuildStageTest.groovy
+++ b/test/BuildStageTest.groovy
@@ -1,6 +1,7 @@
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.doReturn
 
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
@@ -9,11 +10,19 @@ import de.bechte.junit.runners.context.HierarchicalContextRunner
 class BuildStageTest {
 
     public class Build {
+        @After
+        void reset() {
+            Jenkinsfile.original = null
+        }
+
         @Test
         void buildsWithoutError() {
-            BuildStage stage = spy(new BuildStage())
+            def expectedPipelineConfig = { -> }
+            Jenkinsfile.original = new Expando()
+            Jenkinsfile.original.ApplyJenkinsfileClosure = { closure -> }
 
-            doReturn { -> }.when(stage).pipelineConfiguration()
+            BuildStage stage = spy(new BuildStage())
+            doReturn(expectedPipelineConfig).when(stage).pipelineConfiguration()
 
             stage.build()
         }

--- a/test/RegressionStageTest.groovy
+++ b/test/RegressionStageTest.groovy
@@ -15,10 +15,13 @@ class RegressionStageTest {
         void reset() {
             TerraformEnvironmentStage.resetPlugins()
             Jenkinsfile.instance = mock(Jenkinsfile.class)
+            Jenkinsfile.original = null
         }
 
         private configureJenkins(Map config = [:]) {
             Jenkinsfile.instance = mock(Jenkinsfile.class)
+            Jenkinsfile.original = new Expando()
+            Jenkinsfile.original.ApplyJenkinsfileClosure = { closure -> }
             when(Jenkinsfile.instance.getStandardizedRepoSlug()).thenReturn(config.repoSlug)
             when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
         }

--- a/test/StageDecorationsTest.groovy
+++ b/test/StageDecorationsTest.groovy
@@ -1,0 +1,179 @@
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
+
+@RunWith(HierarchicalContextRunner.class)
+class StageDecorationsTest {
+    class WithoutGroup {
+        @Test
+        void applyEmptyDecorationsShouldRunInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decorations = new StageDecorations()
+
+            decorations.apply {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        @Test
+        void applyAddedDecorationsAroundInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decoration = spy { nestedClosure -> nestedClosure() }
+
+            def decorations = new StageDecorations()
+            decorations.add(decoration)
+
+            decorations.apply {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        private class TestSpy {
+            public foo() { return }
+            public inlinedClosureCalled() { return }
+            public innerClosureCalled() { return }
+            public middleClosureCalled() { return }
+            public outerClosureCalled() { return }
+        }
+
+        @Test
+        void applyHandlesMultipleNestedClosures() {
+            def testSpy = spy(new TestSpy())
+
+            def inlinedClosure = { -> testSpy.inlinedClosureCalled() }
+            def outerClosure = { nestedClosure -> nestedClosure(); testSpy.outerClosureCalled() }
+            def middleClosure = { nestedClosure -> nestedClosure(); testSpy.middleClosureCalled() }
+            def innerClosure = { nestedClosure -> nestedClosure(); testSpy.innerClosureCalled() }
+
+            def decorations = new StageDecorations()
+            decorations.add(innerClosure)
+            decorations.add(middleClosure)
+            decorations.add(outerClosure)
+
+            decorations.apply {
+                inlinedClosure()
+            }
+
+            verify(testSpy, times(1)).outerClosureCalled()
+            verify(testSpy, times(1)).middleClosureCalled()
+            verify(testSpy, times(1)).innerClosureCalled()
+            verify(testSpy, times(1)).inlinedClosureCalled()
+        }
+    }
+
+    class WithGroup {
+        @Test
+        void applyEmptyDecorationsShouldRunInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decorations = new StageDecorations()
+
+            decorations.apply('group1') {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        @Test
+        void applyAddedDecorationsAroundInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decoration = spy { nestedClosure -> nestedClosure() }
+            def group = 'somegroup'
+
+            def decorations = new StageDecorations()
+            decorations.add(group, decoration)
+
+            decorations.apply(group) {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        private class TestSpy {
+            public foo() { return }
+            public inlinedClosureCalled() { return }
+            public innerClosureCalled() { return }
+            public middleClosureCalled() { return }
+            public outerClosureCalled() { return }
+        }
+
+        @Test
+        void applyHandlesMultipleNestedClosures() {
+            def testSpy = spy(new TestSpy())
+            def group = 'somegroup'
+
+            def inlinedClosure = { -> testSpy.inlinedClosureCalled() }
+            def outerClosure = { nestedClosure -> nestedClosure(); testSpy.outerClosureCalled() }
+            def middleClosure = { nestedClosure -> nestedClosure(); testSpy.middleClosureCalled() }
+            def innerClosure = { nestedClosure -> nestedClosure(); testSpy.innerClosureCalled() }
+
+            def decorations = new StageDecorations()
+            decorations.add(group, innerClosure)
+            decorations.add(group, middleClosure)
+            decorations.add(group, outerClosure)
+
+            decorations.apply(group) {
+                inlinedClosure()
+            }
+
+            verify(testSpy, times(1)).outerClosureCalled()
+            verify(testSpy, times(1)).middleClosureCalled()
+            verify(testSpy, times(1)).innerClosureCalled()
+            verify(testSpy, times(1)).inlinedClosureCalled()
+        }
+    }
+
+    class WithAndWithoutGroups {
+        private class TestSpy {
+            public foo() { return }
+        }
+
+        @Test
+        void applyWithoutGroupDoesNotRunGroupdDecorations() {
+            def withoutGroup = spy(new TestSpy())
+            def withGroup = spy(new TestSpy())
+            def group = 'somegroup'
+
+            def closureWithoutGroup = { innerClosure -> withoutGroup.foo() }
+            def closureWithGroup = { innerClosure -> withGroup.foo() }
+
+            def decorations = new StageDecorations()
+            decorations.add(closureWithoutGroup)
+            decorations.add(group, closureWithGroup)
+
+            decorations.apply { -> }
+
+            verify(withoutGroup, times(1)).foo()
+            verify(withGroup, times(0)).foo()
+        }
+
+        @Test
+        void applyWithGroupDoesNotRunDecorationsWithoutGroups() {
+            def withoutGroup = spy(new TestSpy())
+            def withGroup = spy(new TestSpy())
+            def group = 'somegroup'
+
+            def closureWithoutGroup = { innerClosure -> withoutGroup.foo() }
+            def closureWithGroup = { innerClosure -> withGroup.foo() }
+
+            def decorations = new StageDecorations()
+            decorations.add(closureWithoutGroup)
+            decorations.add(group, closureWithGroup)
+
+            decorations.apply(group) { -> }
+
+            verify(withoutGroup, times(0)).foo()
+            verify(withGroup, times(1)).foo()
+        }
+
+    }
+}

--- a/vars/ApplyJenkinsfileClosure.groovy
+++ b/vars/ApplyJenkinsfileClosure.groovy
@@ -1,0 +1,4 @@
+def call(closure) {
+    closure.delegate = this
+    closure.call()
+}


### PR DESCRIPTION
* Don't override `node` in Jenkinsfile to control the node label - be explicit
* Stop using invokeMethod in Jenkinsfile, execute DSL within the context of Jenkinsfile using `ApplyJenkinsfileClosure`
* Stop copy-paste of Stage decorations - delegate behavior to new `StageDecorations`
* Fix CPS mismatch errors that show up in latest pipeline plugins.