### PR TITLE
Create v5.5 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #194](https://github.com/manheim/terraform-pipeline/issues/194) Add support global tfvars files.
 * [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
 * [Issue #196](https://github.com/manheim/terraform-pipeline/issues/196) Fix defect - Excessive nested closures in Jenkinsfile.init.  Drop support for deprecated `Jenkinsfile.init(this,env)`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
+
 # v5.4
 
 * [Issue #87](https://github.com/manheim/terraform-pipeline/issues/87) Add travis CI support to the project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v5.5
+
 * [Issue #151](https://github.com/manheim/terraform-pipeline/issues/151) Fix CPS mismatch errors, reduce meta magic in Jenkinsfile.groovy and Stage decorations
 * [Issue #194](https://github.com/manheim/terraform-pipeline/issues/194) Add support global tfvars files.
 * [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #151](https://github.com/manheim/terraform-pipeline/issues/151) Fix CPS mismatch errors, reduce meta magic in Jenkinsfile.groovy and Stage decorations
 * [Issue #194](https://github.com/manheim/terraform-pipeline/issues/194) Add support global tfvars files.
 * [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
 * [Issue #196](https://github.com/manheim/terraform-pipeline/issues/196) Fix defect - Excessive nested closures in Jenkinsfile.init.  Drop support for deprecated `Jenkinsfile.init(this,env)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
+* [Issue #196](https://github.com/manheim/terraform-pipeline/issues/196) Fix defect - Excessive nested closures in Jenkinsfile.init.  Drop support for deprecated `Jenkinsfile.init(this,env)`
 
 # v5.4
 

--- a/docs/TfvarsFilesPlugin.md
+++ b/docs/TfvarsFilesPlugin.md
@@ -2,7 +2,7 @@
 
 This plugin allows you to add `-var-file=${environment}.tfvars` to your plan
 and apply commands.  It supports being configured for a directory relative to
-to the git root. 
+to the git root and global files being applied to every plan and apply command.
 
 For the following repository:
 
@@ -14,8 +14,12 @@ For the following repository:
 └── tfvars
     ├── qa.tfvars
     ├── uat.tfvars
-    └── prod.tfvars
+    ├── prod.tfvars
+    └── global.tfvars
 ```
+This Jenkinsfile setup will include a `-var-file` argument for both
+`qa.tfvars` and `global.tfvars` on the QA plan and apply commands.  Similarly,
+the UAT commands will include `uat.tfvars` and `global.tfvars`.
 
 ```
 // Jenkinsfile
@@ -23,7 +27,9 @@ For the following repository:
 
 Jenkinsfile.init(this)
 
-TfvarsFilesPlugin.withDirectory('./tfvars').init()
+TfvarsFilesPlugin.withDirectory('./tfvars')
+                 .withGlobalVarFile('global.tfvars')
+                 .init()
 
 def validate = new TerraformValidateStage()
 

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -7,22 +7,6 @@ class Jenkinsfile {
     public static declarative = false
     public static pipelineTemplate
 
-    def node(Closure closure) {
-        closure.delegate = original
-        String label = getNodeName()
-        if (label != null) {
-            echo "Using node: ${label}"
-            original.node(label, closure)
-        } else {
-            echo "defaultNodeName and DEFAULT_NODE_NAME environment variable are null"
-            original.node(closure)
-        }
-    }
-
-    def invokeMethod(String name, args) {
-        original.invokeMethod(name, args)
-    }
-
     def String getStandardizedRepoSlug() {
         if (repoSlug != null) {
             return repoSlug
@@ -84,8 +68,7 @@ class Jenkinsfile {
     }
 
     public static build(Closure closure) {
-        closure.delegate = this.instance
-        closure.call()
+        original.ApplyJenkinsfileClosure(closure)
     }
 
     public static void build(List<Stage> stages) {

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -75,11 +75,6 @@ class Jenkinsfile {
         }
     }
 
-    // Deprecate this, env should come from original
-    def static void init(original, env, Class customizations=null) {
-        init(original, customizations)
-    }
-
     def static void initializeDefaultPlugins() {
         TerraformPlugin.init()
     }

--- a/src/StageDecorations.groovy
+++ b/src/StageDecorations.groovy
@@ -1,0 +1,23 @@
+class StageDecorations {
+    private Map<String,Closure> decorations = [:]
+
+    public apply(String group = null, Closure innerClosure) {
+        def currentDecorations = decorations.get(group) ?: { stage -> stage() }
+        currentDecorations.delegate = innerClosure.owner
+        currentDecorations(innerClosure)
+    }
+
+    public add(String group = null, Closure decoration) {
+        def existingDecoration = decorations.get(group) ?: { stage -> stage() }
+        def newDecoration = { stage ->
+            decoration.delegate = delegate
+            decoration() {
+                stage.delegate = delegate
+                existingDecoration.delegate = delegate
+                existingDecoration(stage)
+            }
+        }
+
+        decorations.put(group, newDecoration)
+    }
+}

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -21,7 +21,7 @@ class TerraformEnvironmentStage implements Stage {
         this.decorations = [:]
     }
 
-    public Stage then(Stage nextStages) {
+    public Stage then(Stage nextStage) {
         return new BuildGraph(this).then(nextStage)
     }
 

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -1,7 +1,7 @@
 class TerraformEnvironmentStage implements Stage {
     private Jenkinsfile jenkinsfile
     private String environment
-    private Map<String,Closure> decorations
+    private StageDecorations decorations
     private TerraformInitCommand initCommand
     private TerraformPlanCommand planCommand
     private TerraformApplyCommand applyCommand
@@ -18,7 +18,7 @@ class TerraformEnvironmentStage implements Stage {
     TerraformEnvironmentStage(String environment) {
         this.environment = environment
         this.jenkinsfile = Jenkinsfile.instance
-        this.decorations = [:]
+        this.decorations = new StageDecorations()
     }
 
     public Stage then(Stage nextStage) {
@@ -55,29 +55,29 @@ class TerraformEnvironmentStage implements Stage {
 
         def String environment = this.environment
         return { ->
-            node {
+            node(jenkinsfile.getNodeName()) {
                 deleteDir()
                 checkout(scm)
 
-                applyDecorations(ALL) {
+                decorations.apply(ALL) {
                     stage("${PLAN}-${environment}") {
-                        applyDecorations(PLAN) {
+                        decorations.apply(PLAN) {
                             sh initCommand.toString()
                             sh planCommand.toString()
                         }
                     }
 
-                    applyDecorationsAround(CONFIRM) {
+                    decorations.apply("Around-${CONFIRM}") {
                         stage("${CONFIRM}-${environment}") {
-                            applyDecorations(CONFIRM) {
+                            decorations.apply(CONFIRM) {
                                 echo "Approved"
                             }
                         }
                     }
 
-                    applyDecorationsAround(APPLY) {
+                    decorations.apply("Around-${APPLY}") {
                         stage("${APPLY}-${environment}") {
-                            applyDecorations(APPLY) {
+                            decorations.apply(APPLY) {
                                 sh initCommand.toString()
                                 sh applyCommand.toString()
                             }
@@ -88,33 +88,12 @@ class TerraformEnvironmentStage implements Stage {
         }
     }
 
-    private void applyDecorations(String stageName, Closure stageClosure) {
-        def stageDecorations = decorations.get(stageName) ?: { stage -> stage() }
-        stageDecorations.delegate = jenkinsfile
-        stageDecorations(stageClosure)
-    }
-
     public decorate(String stageName, Closure decoration) {
-        def existingDecorations = decorations.get(stageName) ?: { stage -> stage() }
-        def newDecoration = { stage ->
-            decoration.delegate = delegate
-            decoration.resolveStrategy = Closure.DELEGATE_FIRST
-            decoration() {
-                stage.delegate = delegate
-                existingDecorations.delegate = delegate
-                existingDecorations(stage)
-            }
-        }
-
-        decorations.put(stageName, newDecoration)
-    }
-
-    private void applyDecorationsAround(String stageName, Closure stageClosure) {
-        applyDecorations("Around-${stageName}", stageClosure)
+        decorations.add(stageName, decoration)
     }
 
     public decorateAround(String stageName, Closure decoration) {
-        decorate("Around-${stageName}", decoration)
+        decorations.add("Around-${stageName}", decoration)
     }
 
     public String toString() {

--- a/src/TerraformValidateStage.groovy
+++ b/src/TerraformValidateStage.groovy
@@ -1,6 +1,6 @@
 class TerraformValidateStage implements Stage {
     private Jenkinsfile jenkinsfile
-    private Map<String,Closure> decorations
+    private StageDecorations decorations
 
     private static globalPlugins = []
 
@@ -9,7 +9,7 @@ class TerraformValidateStage implements Stage {
 
     public TerraformValidateStage() {
         this.jenkinsfile = Jenkinsfile.instance
-        this.decorations = [:]
+        this.decorations = new StageDecorations()
     }
 
     public Stage then(Stage nextStage) {
@@ -26,13 +26,13 @@ class TerraformValidateStage implements Stage {
         def validateCommand = TerraformValidateCommand.instance()
 
         return {
-            node {
+            node(jenkinsfile.getNodeName()) {
                 deleteDir()
                 checkout(scm)
 
-                applyDecorations(ALL) {
+                decorations.apply(ALL) {
                     stage("validate") {
-                        applyDecorations(VALIDATE) {
+                        decorations.apply(VALIDATE) {
                             sh validateCommand.toString()
                         }
                     }
@@ -41,34 +41,8 @@ class TerraformValidateStage implements Stage {
         }
     }
 
-    private void applyDecorations(String stageName, Closure stageClosure) {
-        def stageDecorations = decorations.get(stageName) ?: { stage -> stage() }
-        stageDecorations.delegate = jenkinsfile
-        stageDecorations(stageClosure)
-    }
-
     public decorate(String stageName, Closure decoration) {
-        def existingDecorations = decorations.get(stageName) ?: { stage -> stage() }
-
-        def newDecoration = { stage ->
-            decoration.delegate = delegate
-            decoration.resolveStrategy = Closure.DELEGATE_FIRST
-            decoration() {
-                stage.delegate = delegate
-                existingDecorations.delegate = delegate
-                existingDecorations(stage)
-            }
-        }
-
-        decorations.put(stageName, newDecoration)
-    }
-
-    private void applyDecorationsAround(String stageName, Closure stageClosure) {
-        applyDecorations("Around-${stageName}", stageClosure)
-    }
-
-    public decorateAround(String stageName, Closure decoration) {
-        decorate("Around-${stageName}", decoration)
+        decorations.add(stageName, decoration)
     }
 
     public static addPlugin(plugin) {

--- a/test/BuildStageTest.groovy
+++ b/test/BuildStageTest.groovy
@@ -1,6 +1,7 @@
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.doReturn
 
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
@@ -9,11 +10,19 @@ import de.bechte.junit.runners.context.HierarchicalContextRunner
 class BuildStageTest {
 
     public class Build {
+        @After
+        void reset() {
+            Jenkinsfile.original = null
+        }
+
         @Test
         void buildsWithoutError() {
-            BuildStage stage = spy(new BuildStage())
+            def expectedPipelineConfig = { -> }
+            Jenkinsfile.original = new Expando()
+            Jenkinsfile.original.ApplyJenkinsfileClosure = { closure -> }
 
-            doReturn { -> }.when(stage).pipelineConfiguration()
+            BuildStage stage = spy(new BuildStage())
+            doReturn(expectedPipelineConfig).when(stage).pipelineConfiguration()
 
             stage.build()
         }

--- a/test/RegressionStageTest.groovy
+++ b/test/RegressionStageTest.groovy
@@ -15,10 +15,13 @@ class RegressionStageTest {
         void reset() {
             TerraformEnvironmentStage.resetPlugins()
             Jenkinsfile.instance = mock(Jenkinsfile.class)
+            Jenkinsfile.original = null
         }
 
         private configureJenkins(Map config = [:]) {
             Jenkinsfile.instance = mock(Jenkinsfile.class)
+            Jenkinsfile.original = new Expando()
+            Jenkinsfile.original.ApplyJenkinsfileClosure = { closure -> }
             when(Jenkinsfile.instance.getStandardizedRepoSlug()).thenReturn(config.repoSlug)
             when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
         }

--- a/test/StageDecorationsTest.groovy
+++ b/test/StageDecorationsTest.groovy
@@ -24,7 +24,7 @@ class StageDecorationsTest {
         @Test
         void applyAddedDecorationsAroundInnerClosure() {
             def testSpy = spy(new TestSpy())
-            def decoration = spy { nestedClosure -> nestedClosure() }
+            def decoration = { nestedClosure -> nestedClosure() }
 
             def decorations = new StageDecorations()
             decorations.add(decoration)
@@ -36,19 +36,10 @@ class StageDecorationsTest {
             verify(testSpy, times(1)).foo()
         }
 
-        private class TestSpy {
-            public foo() { return }
-            public inlinedClosureCalled() { return }
-            public innerClosureCalled() { return }
-            public middleClosureCalled() { return }
-            public outerClosureCalled() { return }
-        }
-
         @Test
         void applyHandlesMultipleNestedClosures() {
             def testSpy = spy(new TestSpy())
 
-            def inlinedClosure = { -> testSpy.inlinedClosureCalled() }
             def outerClosure = { nestedClosure -> nestedClosure(); testSpy.outerClosureCalled() }
             def middleClosure = { nestedClosure -> nestedClosure(); testSpy.middleClosureCalled() }
             def innerClosure = { nestedClosure -> nestedClosure(); testSpy.innerClosureCalled() }
@@ -59,13 +50,21 @@ class StageDecorationsTest {
             decorations.add(outerClosure)
 
             decorations.apply {
-                inlinedClosure()
+                testSpy.inlinedClosureCalled()
             }
 
             verify(testSpy, times(1)).outerClosureCalled()
             verify(testSpy, times(1)).middleClosureCalled()
             verify(testSpy, times(1)).innerClosureCalled()
             verify(testSpy, times(1)).inlinedClosureCalled()
+        }
+
+        private class TestSpy {
+            public foo() { return }
+            public inlinedClosureCalled() { return }
+            public innerClosureCalled() { return }
+            public middleClosureCalled() { return }
+            public outerClosureCalled() { return }
         }
     }
 
@@ -85,7 +84,7 @@ class StageDecorationsTest {
         @Test
         void applyAddedDecorationsAroundInnerClosure() {
             def testSpy = spy(new TestSpy())
-            def decoration = spy { nestedClosure -> nestedClosure() }
+            def decoration = { nestedClosure -> nestedClosure() }
             def group = 'somegroup'
 
             def decorations = new StageDecorations()
@@ -98,20 +97,11 @@ class StageDecorationsTest {
             verify(testSpy, times(1)).foo()
         }
 
-        private class TestSpy {
-            public foo() { return }
-            public inlinedClosureCalled() { return }
-            public innerClosureCalled() { return }
-            public middleClosureCalled() { return }
-            public outerClosureCalled() { return }
-        }
-
         @Test
         void applyHandlesMultipleNestedClosures() {
             def testSpy = spy(new TestSpy())
             def group = 'somegroup'
 
-            def inlinedClosure = { -> testSpy.inlinedClosureCalled() }
             def outerClosure = { nestedClosure -> nestedClosure(); testSpy.outerClosureCalled() }
             def middleClosure = { nestedClosure -> nestedClosure(); testSpy.middleClosureCalled() }
             def innerClosure = { nestedClosure -> nestedClosure(); testSpy.innerClosureCalled() }
@@ -122,7 +112,7 @@ class StageDecorationsTest {
             decorations.add(group, outerClosure)
 
             decorations.apply(group) {
-                inlinedClosure()
+                testSpy.inlinedClosureCalled()
             }
 
             verify(testSpy, times(1)).outerClosureCalled()
@@ -130,13 +120,17 @@ class StageDecorationsTest {
             verify(testSpy, times(1)).innerClosureCalled()
             verify(testSpy, times(1)).inlinedClosureCalled()
         }
+
+        private class TestSpy {
+            public foo() { return }
+            public inlinedClosureCalled() { return }
+            public innerClosureCalled() { return }
+            public middleClosureCalled() { return }
+            public outerClosureCalled() { return }
+        }
     }
 
     class WithAndWithoutGroups {
-        private class TestSpy {
-            public foo() { return }
-        }
-
         @Test
         void applyWithoutGroupDoesNotRunGroupdDecorations() {
             def withoutGroup = spy(new TestSpy())
@@ -175,5 +169,8 @@ class StageDecorationsTest {
             verify(withGroup, times(1)).foo()
         }
 
+        private class TestSpy {
+            public foo() { return }
+        }
     }
 }

--- a/test/StageDecorationsTest.groovy
+++ b/test/StageDecorationsTest.groovy
@@ -1,0 +1,179 @@
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
+
+@RunWith(HierarchicalContextRunner.class)
+class StageDecorationsTest {
+    class WithoutGroup {
+        @Test
+        void applyEmptyDecorationsShouldRunInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decorations = new StageDecorations()
+
+            decorations.apply {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        @Test
+        void applyAddedDecorationsAroundInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decoration = spy { nestedClosure -> nestedClosure() }
+
+            def decorations = new StageDecorations()
+            decorations.add(decoration)
+
+            decorations.apply {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        private class TestSpy {
+            public foo() { return }
+            public inlinedClosureCalled() { return }
+            public innerClosureCalled() { return }
+            public middleClosureCalled() { return }
+            public outerClosureCalled() { return }
+        }
+
+        @Test
+        void applyHandlesMultipleNestedClosures() {
+            def testSpy = spy(new TestSpy())
+
+            def inlinedClosure = { -> testSpy.inlinedClosureCalled() }
+            def outerClosure = { nestedClosure -> nestedClosure(); testSpy.outerClosureCalled() }
+            def middleClosure = { nestedClosure -> nestedClosure(); testSpy.middleClosureCalled() }
+            def innerClosure = { nestedClosure -> nestedClosure(); testSpy.innerClosureCalled() }
+
+            def decorations = new StageDecorations()
+            decorations.add(innerClosure)
+            decorations.add(middleClosure)
+            decorations.add(outerClosure)
+
+            decorations.apply {
+                inlinedClosure()
+            }
+
+            verify(testSpy, times(1)).outerClosureCalled()
+            verify(testSpy, times(1)).middleClosureCalled()
+            verify(testSpy, times(1)).innerClosureCalled()
+            verify(testSpy, times(1)).inlinedClosureCalled()
+        }
+    }
+
+    class WithGroup {
+        @Test
+        void applyEmptyDecorationsShouldRunInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decorations = new StageDecorations()
+
+            decorations.apply('group1') {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        @Test
+        void applyAddedDecorationsAroundInnerClosure() {
+            def testSpy = spy(new TestSpy())
+            def decoration = spy { nestedClosure -> nestedClosure() }
+            def group = 'somegroup'
+
+            def decorations = new StageDecorations()
+            decorations.add(group, decoration)
+
+            decorations.apply(group) {
+                testSpy.foo()
+            }
+
+            verify(testSpy, times(1)).foo()
+        }
+
+        private class TestSpy {
+            public foo() { return }
+            public inlinedClosureCalled() { return }
+            public innerClosureCalled() { return }
+            public middleClosureCalled() { return }
+            public outerClosureCalled() { return }
+        }
+
+        @Test
+        void applyHandlesMultipleNestedClosures() {
+            def testSpy = spy(new TestSpy())
+            def group = 'somegroup'
+
+            def inlinedClosure = { -> testSpy.inlinedClosureCalled() }
+            def outerClosure = { nestedClosure -> nestedClosure(); testSpy.outerClosureCalled() }
+            def middleClosure = { nestedClosure -> nestedClosure(); testSpy.middleClosureCalled() }
+            def innerClosure = { nestedClosure -> nestedClosure(); testSpy.innerClosureCalled() }
+
+            def decorations = new StageDecorations()
+            decorations.add(group, innerClosure)
+            decorations.add(group, middleClosure)
+            decorations.add(group, outerClosure)
+
+            decorations.apply(group) {
+                inlinedClosure()
+            }
+
+            verify(testSpy, times(1)).outerClosureCalled()
+            verify(testSpy, times(1)).middleClosureCalled()
+            verify(testSpy, times(1)).innerClosureCalled()
+            verify(testSpy, times(1)).inlinedClosureCalled()
+        }
+    }
+
+    class WithAndWithoutGroups {
+        private class TestSpy {
+            public foo() { return }
+        }
+
+        @Test
+        void applyWithoutGroupDoesNotRunGroupdDecorations() {
+            def withoutGroup = spy(new TestSpy())
+            def withGroup = spy(new TestSpy())
+            def group = 'somegroup'
+
+            def closureWithoutGroup = { innerClosure -> withoutGroup.foo() }
+            def closureWithGroup = { innerClosure -> withGroup.foo() }
+
+            def decorations = new StageDecorations()
+            decorations.add(closureWithoutGroup)
+            decorations.add(group, closureWithGroup)
+
+            decorations.apply { -> }
+
+            verify(withoutGroup, times(1)).foo()
+            verify(withGroup, times(0)).foo()
+        }
+
+        @Test
+        void applyWithGroupDoesNotRunDecorationsWithoutGroups() {
+            def withoutGroup = spy(new TestSpy())
+            def withGroup = spy(new TestSpy())
+            def group = 'somegroup'
+
+            def closureWithoutGroup = { innerClosure -> withoutGroup.foo() }
+            def closureWithGroup = { innerClosure -> withGroup.foo() }
+
+            def decorations = new StageDecorations()
+            decorations.add(closureWithoutGroup)
+            decorations.add(group, closureWithGroup)
+
+            decorations.apply(group) { -> }
+
+            verify(withoutGroup, times(0)).foo()
+            verify(withGroup, times(1)).foo()
+        }
+
+    }
+}

--- a/test/TerraformEnvironmentStageTest.groovy
+++ b/test/TerraformEnvironmentStageTest.groovy
@@ -19,6 +19,19 @@ class TerraformEnvironmentStageTest {
         TerraformEnvironmentStage.resetPlugins()
     }
 
+    public class Then {
+
+        @Test
+        void nextStageisCalled() {
+            def stage  = new TerraformEnvironmentStage('foo')
+            def stage2 = new TerraformEnvironmentStage('foo2')
+
+            def result = stage.then(stage2)
+
+            assertThat(result, isA(BuildGraph.class))
+        }
+    }
+
     public class AddedPlugins {
         @Test
         void willHaveApplyCalled() {

--- a/test/TfvarsFilesPluginTest.groovy
+++ b/test/TfvarsFilesPluginTest.groovy
@@ -37,6 +37,10 @@ class TfvarsFilesPluginTest {
         TfvarsFilesPlugin.withDirectory(directory).init()
     }
 
+    static void initWithGlobalFile(String file) {
+        TfvarsFilesPlugin.withGlobalVarFile(file).init()
+    }
+
     static void reset() {
         TerraformPlanCommand.resetPlugins()
         TerraformApplyCommand.resetPlugins()
@@ -106,6 +110,30 @@ class TfvarsFilesPluginTest {
         }
 
         @Test
+        void addsGlobalFileIfFileExists() {
+            fileWillExist()
+            initWithGlobalFile("globals.tfvars")
+            def command = TerraformApplyCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./globals.tfvars'))
+        }
+
+        @Test
+        void doesNotAddGlobalFileIfFileDoesntExist() {
+            fileWillNotExist()
+            initWithGlobalFile("globals.tfvars")
+            def command = TerraformApplyCommand.instanceFor('test')
+            assertThat(command.toString(), not(containsString('-var-file=./globals.tfvars')))
+        }
+
+        @Test
+        void globalRespectsDirectorySetting() {
+            fileWillExist()
+            TfvarsFilesPlugin.withDirectory("./resources").withGlobalVarFile('globals.tfvars').init()
+            def command = TerraformApplyCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./resources/globals.tfvars'))
+        }
+
+        @Test
         void respectsDirectorySetting() {
             fileWillExist()
             initWithDir('./resources')
@@ -113,40 +141,64 @@ class TfvarsFilesPluginTest {
             def command = TerraformApplyCommand.instanceFor('test')
             assertThat(command.toString(), containsString('-var-file=./resources/test.tfvars'))
         }
+    }
 
-        class PlanCommand {
+    class PlanCommand {
 
-            @After
-            void resetPlugins() {
-                reset()
-            }
+        @After
+        void resetPlugins() {
+            reset()
+        }
 
-            @Test
-            void returnsArgumentIfFileExists() {
-                fileWillExist()
-                initPlugin()
+        @Test
+        void returnsArgumentIfFileExists() {
+            fileWillExist()
+            initPlugin()
 
-                def command = TerraformPlanCommand.instanceFor('test')
-                assertThat(command.toString(), containsString('-var-file=./test.tfvars'))
-            }
+            def command = TerraformPlanCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./test.tfvars'))
+        }
 
-            @Test
-            void doesNotAddArgIfFileDoesntExists() {
-                fileWillNotExist()
-                initPlugin()
+        @Test
+        void doesNotAddArgIfFileDoesntExists() {
+            fileWillNotExist()
+            initPlugin()
 
-                def command = TerraformPlanCommand.instanceFor('test')
-                assertThat(command.toString(), not(containsString('-var-file')))
-            }
+            def command = TerraformPlanCommand.instanceFor('test')
+            assertThat(command.toString(), not(containsString('-var-file')))
+        }
 
-            @Test
-            void respectsDirectorySetting() {
-                fileWillExist()
-                initWithDir('./resources')
+        @Test
+        void addsGlobalFileIfFileExists() {
+            fileWillExist()
+            initWithGlobalFile("globals.tfvars")
+            def command = TerraformPlanCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./globals.tfvars'))
+        }
 
-                def command = TerraformPlanCommand.instanceFor('test')
-                assertThat(command.toString(), containsString('-var-file=./resources/test.tfvars'))
-            }
+        @Test
+        void doesNotAddGlobalFileIfFileDoesntExist() {
+            fileWillNotExist()
+            initWithGlobalFile("globals.tfvars")
+            def command = TerraformPlanCommand.instanceFor('test')
+            assertThat(command.toString(), not(containsString('-var-file=./globals.tfvars')))
+        }
+
+        @Test
+        void globalRespectsDirectorySetting() {
+            fileWillExist()
+            TfvarsFilesPlugin.withDirectory("./resources").withGlobalVarFile('globals.tfvars').init()
+            def command = TerraformPlanCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./resources/globals.tfvars'))
+        }
+
+        @Test
+        void respectsDirectorySetting() {
+            fileWillExist()
+            initWithDir('./resources')
+
+            def command = TerraformPlanCommand.instanceFor('test')
+            assertThat(command.toString(), containsString('-var-file=./resources/test.tfvars'))
         }
     }
 }

--- a/vars/ApplyJenkinsfileClosure.groovy
+++ b/vars/ApplyJenkinsfileClosure.groovy
@@ -1,0 +1,4 @@
+def call(closure) {
+    closure.delegate = this
+    closure.call()
+}


### PR DESCRIPTION
* [Issue #151](https://github.com/manheim/terraform-pipeline/issues/151) Fix CPS mismatch errors, reduce meta magic in Jenkinsfile.groovy and Stage decorations
* [Issue #194](https://github.com/manheim/terraform-pipeline/issues/194) Add support global tfvars files.
* [Issue #198](https://github.com/manheim/terraform-pipeline/issues/198) Fix using only TerraformEnvironmentStages
* [Issue #196](https://github.com/manheim/terraform-pipeline/issues/196) Fix defect - Excessive nested closures in Jenkinsfile.init.  Drop support for deprecated `Jenkinsfile.init(this,env)`