### PR TITLE
Support suffixes for *ALL* terraform commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* [Issue #221](https://github.com/manheim/terraform-pipeline/issues/221) Support suffixes for terraform commands
+* [Issue #222](https://github.com/manheim/terraform-pipeline/issues/222) TerraformInitCommand - withPrefix doesn't support multiple prefixes
+
 # v5.6
 
 * [Issue #203](https://github.com/manheim/terraform-pipeline/issues/201) ParameterStoreBuildWrapperPlugin - allow path to be customized

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -4,6 +4,7 @@ class TerraformApplyCommand {
     private String command = "apply"
     String environment
     private prefixes = []
+    private suffixes = []
     private args = []
     private static plugins = []
     private appliedPlugins = []
@@ -28,6 +29,11 @@ class TerraformApplyCommand {
         return this
     }
 
+    public TerraformApplyCommand withSuffix(String suffix) {
+        suffixes << suffix
+        return this
+    }
+
     public TerraformApplyCommand withDirectory(String directory) {
         this.directory = directory
         return this
@@ -47,6 +53,8 @@ class TerraformApplyCommand {
         if (directory) {
             pieces << directory
         }
+
+        pieces += suffixes
 
         return pieces.join(' ')
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -5,6 +5,7 @@ class TerraformPlanCommand {
     private String command = "plan"
     String environment
     private prefixes = []
+    private suffixes = []
     private arguments = []
     private static plugins = DEFAULT_PLUGINS.clone()
     private appliedPlugins = []
@@ -21,6 +22,11 @@ class TerraformPlanCommand {
 
     public TerraformPlanCommand withPrefix(String prefix) {
         prefixes << prefix
+        return this
+    }
+
+    public TerraformPlanCommand withSuffix(String suffix) {
+        suffixes << suffix
         return this
     }
 
@@ -48,6 +54,8 @@ class TerraformPlanCommand {
         if (directory) {
             pieces << directory
         }
+
+        pieces += suffixes
 
         return pieces.join(' ')
     }

--- a/src/TerraformValidateCommand.groovy
+++ b/src/TerraformValidateCommand.groovy
@@ -3,6 +3,7 @@ class TerraformValidateCommand {
     private String command = "validate"
     private arguments = []
     private prefixes = []
+    private suffixes = []
     private static globalPlugins = []
     private appliedPlugins = []
     private String directory
@@ -17,6 +18,11 @@ class TerraformValidateCommand {
 
     public TerraformValidateCommand withPrefix(String prefix) {
         prefixes << prefix
+        return this
+    }
+
+    public TerraformValidateCommand withSuffix(String suffix) {
+        suffixes << suffix
         return this
     }
 
@@ -37,6 +43,8 @@ class TerraformValidateCommand {
         if (directory) {
             pieces << directory
         }
+        pieces += suffixes
+
         return pieces.join(' ')
     }
 

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -88,6 +88,35 @@ class TerraformApplyCommandTest {
         }
     }
 
+    public class WithSuffix {
+        @Test
+        void addsSuffixToEndOfCommand() {
+            def command = new TerraformApplyCommand().withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("> /dev/null"))
+        }
+
+        @Test
+        void addsSuffixAfterArgumentsAndDirectories() {
+            def command = new TerraformApplyCommand().withArgument('fakeArg')
+                                                     .withDirectory('fakeDirectory')
+                                                     .withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("> /dev/null"))
+        }
+
+        @Test
+        void isCumulative() {
+            def command = new TerraformPlanCommand().withSuffix("fooSuffix")
+                                                    .withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("fooSuffix > /dev/null"))
+        }
+    }
+
     public class Plugins {
         @After
         void resetPlugins() {

--- a/test/TerraformInitCommandTest.groovy
+++ b/test/TerraformInitCommandTest.groovy
@@ -109,7 +109,6 @@ class TerraformInitCommandTest {
         }
     }
 
-
     public class WithSuffix {
         @Test
         void addsSuffixToEndOfCommand() {

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -69,6 +69,35 @@ class TerraformPlanCommandTest {
         }
     }
 
+    public class WithSuffix {
+        @Test
+        void addsSuffixToEndOfCommand() {
+            def command = new TerraformPlanCommand().withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("> /dev/null"))
+        }
+
+        @Test
+        void addsSuffixAfterArgumentsAndDirectories() {
+            def command = new TerraformPlanCommand().withArgument('fakeArg')
+                                                    .withDirectory('fakeDirectory')
+                                                    .withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("> /dev/null"))
+        }
+
+        @Test
+        void isCumulative() {
+            def command = new TerraformPlanCommand().withSuffix("fooSuffix")
+                                                    .withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("fooSuffix > /dev/null"))
+        }
+    }
+
     public class WithArgument {
         @Test
         void addsArgument() {

--- a/test/TerraformValidateCommandTest.groovy
+++ b/test/TerraformValidateCommandTest.groovy
@@ -41,6 +41,35 @@ class TerraformValidateCommandTest {
         }
     }
 
+    public class WithSuffix {
+        @Test
+        void addsSuffixToEndOfCommand() {
+            def command = new TerraformValidateCommand().withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("> /dev/null"))
+        }
+
+        @Test
+        void addsSuffixAfterArgumentsAndDirectories() {
+            def command = new TerraformValidateCommand().withArgument('fakeArg')
+                                                        .withDirectory('fakeDirectory')
+                                                        .withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("> /dev/null"))
+        }
+
+        @Test
+        void isCumulative() {
+            def command = new TerraformValidateCommand().withSuffix("fooSuffix")
+                                                        .withSuffix("> /dev/null")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, endsWith("fooSuffix > /dev/null"))
+        }
+    }
+
     public class Plugins {
         @After
         void resetPlugins() {


### PR DESCRIPTION
* Issue #221 added suffix support for terraform init, but this functionality is useful for all terraform commands
* Add suffix support to all terraform commands.