### PR TITLE
Issue 218: preserveStash in default declarative templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #218](https://github.com/manheim/terraform-pipeline/issues/218) Preserve stashes in default declarative pipeline templates
 * [Issue #206](https://github.com/manheim/terraform-pipeline/issues/206) Explain the importance of plugin order
 * [Issue #219](https://github.com/manheim/terraform-pipeline/issues/219) Fix documentation - example code does not work
 * [Issue #234](https://github.com/manheim/terraform-pipeline/issues/234) Rename TerraformPlanResultsPRPlugin to be consistent

--- a/vars/Pipeline2Stage.groovy
+++ b/vars/Pipeline2Stage.groovy
@@ -1,6 +1,7 @@
 def call(args) {
     pipeline {
         agent none
+        options { preserveStashes() }
 
         stages {
             stage('1') {

--- a/vars/Pipeline3Stage.groovy
+++ b/vars/Pipeline3Stage.groovy
@@ -1,6 +1,7 @@
 def call(args) {
     pipeline {
         agent none
+        options { preserveStashes() }
 
         stages {
             stage('1') {

--- a/vars/Pipeline4Stage.groovy
+++ b/vars/Pipeline4Stage.groovy
@@ -1,6 +1,7 @@
 def call(args) {
     pipeline {
         agent none
+        options { preserveStashes() }
 
         stages {
             stage('1') {

--- a/vars/Pipeline5Stage.groovy
+++ b/vars/Pipeline5Stage.groovy
@@ -1,6 +1,7 @@
 def call(args) {
     pipeline {
         agent none
+        options { preserveStashes() }
 
         stages {
             stage('1') {

--- a/vars/Pipeline6Stage.groovy
+++ b/vars/Pipeline6Stage.groovy
@@ -1,6 +1,7 @@
 def call(args) {
     pipeline {
         agent none
+        options { preserveStashes() }
 
         stages {
             stage('1') {

--- a/vars/Pipeline7Stage.groovy
+++ b/vars/Pipeline7Stage.groovy
@@ -1,6 +1,7 @@
 def call(args) {
     pipeline {
         agent none
+        options { preserveStashes() }
 
         stages {
             stage('1') {


### PR DESCRIPTION
* Issue #218 
* use preserveStage by default in declarative templates
* Default preserveStage behavior stashes only a single stash (See: https://www.jenkins.io/doc/book/pipeline/running-pipelines/)