### PR TITLE
Support building dockerfile & fix Terraform PR args (supersedes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #230](https://github.com/manheim/terraform-pipeline/issues/230) AgentNode Support with PR Plugin - allow Dockerfile agents
 * [Issue #218](https://github.com/manheim/terraform-pipeline/issues/218) Preserve stashes in default declarative pipeline templates
 * [Issue #206](https://github.com/manheim/terraform-pipeline/issues/206) Explain the importance of plugin order
 * [Issue #219](https://github.com/manheim/terraform-pipeline/issues/219) Fix documentation - example code does not work

--- a/docs/AgentNodePlugin.md
+++ b/docs/AgentNodePlugin.md
@@ -2,18 +2,40 @@
 
 This plugin allows you to run the terraform stages in a docker container. This **DOES NOT WORK WITH AWSSUME** you should be using iam_block with aws provider with terraform.
 
+### Using pre-build docker image
 ```
 // Jenkinsfile
 @Library(['terraform-pipeline']) _
 
 Jenkinsfile.init(this)
 
-AgentNodePlugin.withAgentDockerImage('hashicorp/terraform:0.10.2')
+AgentNodePlugin.withAgentDockerImage("hashicorp/terraform:latest")
                .withAgentDockerImageOptions("--entrypoint=''")
                .init()
 
 def validate = new TerraformValidateStage()
+def deployQA = new TerraformEnvironmentStage('qa')
+def deployUat = new TerraformEnvironmentStage('uat')
+def deployProd = new TerraformEnvironmentStage('prod')
 
+validate.then(deployQA)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```
+
+### Using Dockerfile in repo
+```
+// Jenkinsfile
+@Library(['terraform-pipeline']) _
+
+Jenkinsfile.init(this)
+
+AgentNodePlugin.withAgentDockerImage('custom/terraform-ruby:latest', true)
+               .withAgentDockerImageOptions("--entrypoint=''")
+               .init()
+
+def validate = new TerraformValidateStage()
 def deployQA = new TerraformEnvironmentStage('qa')
 def deployUat = new TerraformEnvironmentStage('uat')
 def deployProd = new TerraformEnvironmentStage('prod')

--- a/docs/AgentNodePlugin.md
+++ b/docs/AgentNodePlugin.md
@@ -33,6 +33,7 @@ Jenkinsfile.init(this)
 
 AgentNodePlugin.withAgentDockerImage('custom/terraform-ruby:latest', true)
                .withAgentDockerImageOptions("--entrypoint=''")
+               .withAgentDockerfile()
                .init()
 
 def validate = new TerraformValidateStage()

--- a/docs/AgentNodePlugin.md
+++ b/docs/AgentNodePlugin.md
@@ -31,7 +31,7 @@ validate.then(deployQA)
 
 Jenkinsfile.init(this)
 
-AgentNodePlugin.withAgentDockerImage('custom/terraform-ruby:latest', true)
+AgentNodePlugin.withAgentDockerImage('custom/terraform-ruby:latest')
                .withAgentDockerImageOptions("--entrypoint=''")
                .withAgentDockerfile()
                .init()
@@ -46,3 +46,27 @@ validate.then(deployQA)
         .then(deployProd)
         .build()
 ```
+
+### Optionally use a Dockerfile with a different filename
+```
+// Jenkinsfile
+@Library(['terraform-pipeline']) _
+
+Jenkinsfile.init(this)
+
+AgentNodePlugin.withAgentDockerImage('custom/terraform-ruby:latest')
+               .withAgentDockerImageOptions("--entrypoint=''")
+               .withAgentDockerfile('MyDockerfile')
+               .init()
+
+def validate = new TerraformValidateStage()
+def deployQA = new TerraformEnvironmentStage('qa')
+def deployUat = new TerraformEnvironmentStage('uat')
+def deployProd = new TerraformEnvironmentStage('prod')
+
+validate.then(deployQA)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```
+

--- a/src/AgentNodePlugin.groovy
+++ b/src/AgentNodePlugin.groovy
@@ -3,6 +3,8 @@ import static TerraformEnvironmentStage.ALL
 
 public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformEnvironmentStagePlugin {
     private static String dockerImage
+    private static boolean withDockerfile
+    private static String dockerBuildOptions
     private static String dockerOptions
 
     AgentNodePlugin() { }
@@ -14,13 +16,19 @@ public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformE
         TerraformEnvironmentStage.addPlugin(plugin)
     }
 
-    public static AgentNodePlugin withAgentDockerImage(String dockerImage) {
+    public static AgentNodePlugin withAgentDockerImage(String dockerImage, withDockerfile=false) {
         this.dockerImage = dockerImage
+        this.withDockerfile = withDockerfile
         return this
     }
 
     public static AgentNodePlugin withAgentDockerImageOptions(String dockerOptions) {
         this.dockerOptions = dockerOptions
+        return this
+    }
+
+    public static AgentNodePlugin withAgentDockerBuildOptions(String dockerBuildOptions) {
+        this.dockerBuildOptions = dockerBuildOptions
         return this
     }
 
@@ -36,8 +44,12 @@ public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformE
 
     public Closure addAgent() {
         return { closure ->
-            if (dockerImage) {
+            if (this.dockerImage && this.withDockerfile == false) {
                 docker.image(this.dockerImage).inside(this.dockerOptions) {
+                    closure()
+                }
+            } else if (this.dockerImage && this.withDockerfile == true) {
+                docker.build(this.dockerImage, "${this.dockerBuildOptions} -f Dockerfile .").inside(this.dockerOptions) {
                     closure()
                 }
             } else {

--- a/src/AgentNodePlugin.groovy
+++ b/src/AgentNodePlugin.groovy
@@ -53,7 +53,12 @@ public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformE
                     closure()
                 }
             } else if (this.dockerImage && this.dockerfile) {
-                docker.build(this.dockerImage, "${this.dockerBuildOptions} -f ${dockerfile} .").inside(this.dockerOptions) {
+                def buildCommand = "-f ${dockerfile} ."
+                if (this.dockerBuildOptions) {
+                    buildCommand = "${this.dockerBuildOptions} ${buildCommand}"
+                }
+
+                docker.build(this.dockerImage, buildCommand.toString()).inside(this.dockerOptions) {
                     closure()
                 }
             } else {

--- a/src/AgentNodePlugin.groovy
+++ b/src/AgentNodePlugin.groovy
@@ -3,7 +3,7 @@ import static TerraformEnvironmentStage.ALL
 
 public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformEnvironmentStagePlugin {
     private static String dockerImage
-    private static boolean withDockerfile
+    private static String dockerfile
     private static String dockerBuildOptions
     private static String dockerOptions
 
@@ -16,19 +16,23 @@ public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformE
         TerraformEnvironmentStage.addPlugin(plugin)
     }
 
-    public static AgentNodePlugin withAgentDockerImage(String dockerImage, withDockerfile=false) {
+    public static withAgentDockerImage(String dockerImage) {
         this.dockerImage = dockerImage
-        this.withDockerfile = withDockerfile
         return this
     }
 
-    public static AgentNodePlugin withAgentDockerImageOptions(String dockerOptions) {
+    public static withAgentDockerImageOptions(String dockerOptions) {
         this.dockerOptions = dockerOptions
         return this
     }
 
-    public static AgentNodePlugin withAgentDockerBuildOptions(String dockerBuildOptions) {
+    public static withAgentDockerBuildOptions(String dockerBuildOptions) {
         this.dockerBuildOptions = dockerBuildOptions
+        return this
+    }
+
+    public static withAgentDockerfile(String dockerfile = 'Dockerfile') {
+        this.dockerfile = dockerfile
         return this
     }
 
@@ -44,17 +48,24 @@ public class AgentNodePlugin implements TerraformValidateStagePlugin, TerraformE
 
     public Closure addAgent() {
         return { closure ->
-            if (this.dockerImage && this.withDockerfile == false) {
+            if (this.dockerImage && this.dockerfile == null) {
                 docker.image(this.dockerImage).inside(this.dockerOptions) {
                     closure()
                 }
-            } else if (this.dockerImage && this.withDockerfile == true) {
-                docker.build(this.dockerImage, "${this.dockerBuildOptions} -f Dockerfile .").inside(this.dockerOptions) {
+            } else if (this.dockerImage && this.dockerfile) {
+                docker.build(this.dockerImage, "${this.dockerBuildOptions} -f ${dockerfile} .").inside(this.dockerOptions) {
                     closure()
                 }
             } else {
                 closure()
             }
         }
+    }
+
+    public static void reset() {
+        dockerImage = null
+        dockerfile = null
+        dockerBuildOptions = null
+        dockerOptions = null
     }
 }

--- a/test/AgentNodePluginTest.groovy
+++ b/test/AgentNodePluginTest.groovy
@@ -1,0 +1,242 @@
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import de.bechte.junit.runners.context.HierarchicalContextRunner
+
+@RunWith(HierarchicalContextRunner.class)
+class AgentNodePluginTest {
+    private createJenkinsfileSpy() {
+        def dummyJenkinsfile = spy(new DummyJenkinsfile())
+        dummyJenkinsfile.docker = dummyJenkinsfile
+
+        return dummyJenkinsfile
+    }
+
+    public class Init {
+        @After
+        void resetPlugins() {
+            TerraformValidateStage.resetPlugins()
+            TerraformEnvironmentStage.resetPlugins()
+        }
+
+        @Test
+        void modifiesTerraformEnvironmentStage() {
+            AgentNodePlugin.init()
+
+            Collection actualPlugins = TerraformEnvironmentStage.getPlugins()
+            assertThat(actualPlugins, hasItem(instanceOf(AgentNodePlugin.class)))
+        }
+
+        @Test
+        void modifiesTerraformValidateStage() {
+            AgentNodePlugin.init()
+
+            Collection actualPlugins = TerraformValidateStage.getPlugins()
+            assertThat(actualPlugins, hasItem(instanceOf(AgentNodePlugin.class)))
+        }
+    }
+
+    class Apply {
+        @Test
+        void addsAgentClosureToTerraformEnvironmentStage() {
+            def expectedClosure = { -> }
+            def plugin = spy(new AgentNodePlugin())
+            doReturn(expectedClosure).when(plugin).addAgent()
+            def stage = mock(TerraformEnvironmentStage.class)
+
+            plugin.apply(stage)
+
+            verify(stage).decorate(anyString(), eq(expectedClosure))
+        }
+
+        @Test
+        void addsAgentClosureToTerraformValidateStage() {
+            def expectedClosure = { -> }
+            def plugin = spy(new AgentNodePlugin())
+            doReturn(expectedClosure).when(plugin).addAgent()
+            def stage = mock(TerraformValidateStage.class)
+
+            plugin.apply(stage)
+
+            verify(stage).decorate(anyString(), eq(expectedClosure))
+        }
+    }
+
+    class AddAgent {
+        class WithNoDockerEnabled {
+            @Test
+            void callsTheInnerclosure() {
+                def plugin = new AgentNodePlugin()
+                def innerClosure = spy { -> }
+
+                def agentClosure = plugin.addAgent()
+
+                agentClosure(innerClosure)
+
+                verify(innerClosure).call()
+            }
+        }
+
+        class WithDockerImageNoDockerfile {
+            private String expectedImage = 'someImage'
+            @Before
+            void useDockerImage() {
+                AgentNodePlugin.withAgentDockerImage(expectedImage)
+            }
+
+            @After
+            void reset() {
+                AgentNodePlugin.reset()
+            }
+
+            @Test
+            void callsTheInnerClosure() {
+                def plugin = new AgentNodePlugin()
+                def innerClosure = spy { -> }
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = new DummyJenkinsfile()
+                agentClosure(innerClosure)
+
+                verify(innerClosure).call()
+            }
+
+            @Test
+            void usesTheGivenDockerImage() {
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).image(expectedImage)
+            }
+
+            @Test
+            void usesTheGivenDockerOptions() {
+                def expectedOptions = 'someOptions'
+                AgentNodePlugin.withAgentDockerImageOptions(expectedOptions)
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+                jenkinsfile.docker = jenkinsfile
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).inside(eq(expectedOptions), anyObject())
+            }
+        }
+
+        class WithDockerImageAndDockerfile {
+            private String expectedImage = 'someImage'
+            @Before
+            void useDockerImage() {
+                AgentNodePlugin.withAgentDockerImage(expectedImage)
+            }
+
+            @After
+            void reset() {
+                AgentNodePlugin.reset()
+            }
+
+            @Test
+            void callsTheInnerClosure() {
+                AgentNodePlugin.withAgentDockerfile()
+                def plugin = new AgentNodePlugin()
+                def innerClosure = spy { -> }
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = new DummyJenkinsfile()
+                agentClosure(innerClosure)
+
+                verify(innerClosure).call()
+            }
+
+            @Test
+            void usesTheGivenDockerImage() {
+                AgentNodePlugin.withAgentDockerfile()
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).build(eq(expectedImage), anyString())
+            }
+
+            @Test
+            void usesTheGivenDockerBuildOptions() {
+                def expectedOptions = 'expectedOptions'
+                AgentNodePlugin.withAgentDockerfile()
+                               .withAgentDockerBuildOptions(expectedOptions)
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).build(anyString(), contains(expectedOptions))
+            }
+
+            @Test
+            void usesFileNamedDockerfileByDefault() {
+                AgentNodePlugin.withAgentDockerfile()
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).build(anyString(), contains('-f Dockerfile'))
+            }
+
+            @Test
+            void usesGivenDockerfile() {
+                def expectedDockerfile = 'someDockerfile'
+                AgentNodePlugin.withAgentDockerfile(expectedDockerfile)
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).build(anyString(), contains("-f ${expectedDockerfile}"))
+            }
+
+            @Test
+            void usesGivenDockerOptions() {
+                def expectedOptions = 'someOptions'
+                AgentNodePlugin.withAgentDockerfile()
+                               .withAgentDockerImageOptions(expectedOptions)
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).inside(eq(expectedOptions), anyObject())
+            }
+        }
+    }
+}
+

--- a/test/AgentNodePluginTest.groovy
+++ b/test/AgentNodePluginTest.groovy
@@ -181,6 +181,20 @@ class AgentNodePluginTest {
             }
 
             @Test
+            void worksWithoutBuildOptions() {
+                def expectedBuildCommand = '-f Dockerfile .'
+                AgentNodePlugin.withAgentDockerfile('Dockerfile')
+                def plugin = new AgentNodePlugin()
+                def jenkinsfile = createJenkinsfileSpy()
+
+                def agentClosure = plugin.addAgent()
+                agentClosure.delegate = jenkinsfile
+                agentClosure { -> }
+
+                verify(jenkinsfile).build(anyString(), eq(expectedBuildCommand))
+            }
+
+            @Test
             void usesTheGivenDockerBuildOptions() {
                 def expectedOptions = 'expectedOptions'
                 AgentNodePlugin.withAgentDockerfile()

--- a/test/DummyJenkinsfile.groovy
+++ b/test/DummyJenkinsfile.groovy
@@ -1,0 +1,18 @@
+class DummyJenkinsfile {
+    public docker
+
+    public DummyJenkinsfile() {
+        docker = this
+    }
+
+    public docker(Closure closure = null) {
+        return this
+    }
+
+    public image(String dockerImage) { return this }
+    public inside(String dockerImage, Closure closure) {
+        closure()
+        return this
+    }
+    public build(String image, String options) { return this }
+}


### PR DESCRIPTION
This supersedes and continues the work from PR #231 

* Make fixes from PR above
* Simplify the README - don't include unrelated plugins
* Dockerfile should use fluent programming conventions
* Do not hardcode 'Dockerfile' file name - default, but allow it to be overridden
* Add tests
