### PR TITLE
Issue 232: PRPlugin breaks when using DirectoryPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #232](https://github.com/manheim/terraform-pipeline/issues/232) TerraformPlanResultsPR breaks with TerraformDirectoryPlugin
 * [Issue #230](https://github.com/manheim/terraform-pipeline/issues/230) AgentNode Support with PR Plugin - allow Dockerfile agents
 * [Issue #218](https://github.com/manheim/terraform-pipeline/issues/218) Preserve stashes in default declarative pipeline templates
 * [Issue #206](https://github.com/manheim/terraform-pipeline/issues/206) Explain the importance of plugin order

--- a/src/TerraformPlanResultsPRPlugin.groovy
+++ b/src/TerraformPlanResultsPRPlugin.groovy
@@ -44,10 +44,12 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
     @Override
     public void apply(TerraformPlanCommand command) {
         if (landscape) {
-            command.withSuffix(" -out=tfplan 2>plan.err | landscape | tee plan.out")
+            command.withArgument("-out=tfplan")
+            command.withSuffix("2>plan.err | landscape | tee plan.out")
         }
         else {
-            command.withSuffix(" -out=tfplan 2>plan.err | tee plan.out")
+            command.withArgument("-out=tfplan")
+            command.withSuffix("2>plan.err | tee plan.out")
         }
     }
 


### PR DESCRIPTION
*  TerraformPlanPRResultsPlugin adds an out file parameter, which conflicts with the  DirectoryPlugin during `terraform plan`
* `-out=tfplan` is a terraform plan argument and  should use `withArgument` to preserve the correct argument order.