### PR TITLE
Issue 193: Simplify implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [Issue #218](https://github.com/manheim/terraform-pipeline/issues/218) Preserve stashes in default declarative pipeline templates
 * [Issue #206](https://github.com/manheim/terraform-pipeline/issues/206) Explain the importance of plugin order
 * [Issue #219](https://github.com/manheim/terraform-pipeline/issues/219) Fix documentation - example code does not work
-* [Issue #234](https://github.com/manheim/terraform-pipeline/issues/234) Rename TerraformPlanResultsPRPlugin to be consistent
+* [Issue #234](https://github.com/manheim/terraform-pipeline/issues/234) Rename GithubPRPlanPlugin to be consistent
 * [Issue #193](https://github.com/manheim/terraform-pipeline/issues/193) Support passing branch plans to Github PRs
 * [Issue #102](https://github.com/manheim/terraform-pipeline/issues/102) Support target when running terraform plan and apply
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ The example above gives you a bare-bones pipeline, and there may be Jenkinsfile 
 * [AgentNodePlugin](./docs/AgentNodePlugin.md): Run your pipeline on agents that are configured with Docker.
 * [AnsiColorPlugin](./docs/AnsiColorPlugin.md): Enable ansi-color output.
 * [CrqPlugin](./docs/CrqPlugin.md): Use the manheim_remedier gem to open automated Change Requests.
+* [GithubPRPlanPlugin](./docs/GithubPRPlanPlugin.md): Use this to post Terraform plan results in the comments of a Github PullRequest.
 * [TerraformDirectoryPlugin](./docs/TerraformDirectoryPlugin.md): Change the default directory containing your terraform code.
 * [TerraformLandscapePlugin](./docs/TerraformLandscapePlugin.md): Enable terraform-landscape plan output.
-* [GithubPRPlanPlugin](./docs/GithubPRPlanPlugin.md): Use this to post Terraform plan results in the comments of a Github PullRequest.
 * [TargetPlugin](./docs/TargetPlugin.md): set `-target` parameter for terraform plan and apply.
 
 ## Write your own Plugin

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The example above gives you a bare-bones pipeline, and there may be Jenkinsfile 
 * [CrqPlugin](./docs/CrqPlugin.md): Use the manheim_remedier gem to open automated Change Requests.
 * [TerraformDirectoryPlugin](./docs/TerraformDirectoryPlugin.md): Change the default directory containing your terraform code.
 * [TerraformLandscapePlugin](./docs/TerraformLandscapePlugin.md): Enable terraform-landscape plan output.
-* [TerraformPlanResultsPRPlugin](./docs/TerraformPlanResultsPRPlugin.md): Use this to post Terraform plan results in the comments of a PR.
+* [GithubPRPlanPlugin](./docs/GithubPRPlanPlugin.md): Use this to post Terraform plan results in the comments of a Github PullRequest.
 * [TargetPlugin](./docs/TargetPlugin.md): set `-target` parameter for terraform plan and apply.
 
 ## Write your own Plugin

--- a/docs/GithubPRPlanPlugin.md
+++ b/docs/GithubPRPlanPlugin.md
@@ -1,4 +1,4 @@
-## [TerraformPlanResultsPRPlugin](../src/TerraformPlanResultsPRPlugin.groovy)
+## [GithubPRPlanPlugin](../src/GithubPRPlanPlugin.groovy)
 
 Use this to post Terraform plan results in the comments of a PR.
 
@@ -12,7 +12,7 @@ One-Time Setup:
 Jenkinsfile.init(this)
 
 // A GITHUB_TOKEN environment variable should contain your Github PAT
-TerraformPlanResultsPRPlugin.init()
+GithubPRPlanPlugin.init()
 
 def validate = new TerraformValidateStage()
 def deployQa = new TerraformEnvironmentStage('qa')

--- a/docs/TerraformPlanResultsPRPlugin.md
+++ b/docs/TerraformPlanResultsPRPlugin.md
@@ -2,23 +2,13 @@
 
 Use this to post Terraform plan results in the comments of a PR.
 
-One-Time Setup:
-* Install the terraform-landscape gem on your Jenkins agents. (ONLY when using `withLandscape(true)`)
-
 Requirements:
 * Set the environment variable for Github Authentication. The default environment variable to be set is `GITHUB_TOKEN`. The CredentialsPlugin can help with setting this variable.
-* Enable AnsiColorPlugin for colors in Jenkins (ONLY when usng `withLandscape(true)`)
 
 Configuration Methods:
 * `withRepoHost(String)`: specify the Github source address (DEFAULT: "https://api.github.com/")
 * `withRepoSlug(String)`: specify the full repo slug (DEFAULT: "")
-* `withLandscape(bool)`: enable or disable the terraform landscape gem for plan output (DEFAULT: false)
 * `withGithubTokenEnvVar(String)`: specify the environment variable used for github auth (DEFAULT: "GITHUB_TOKEN")
-
-Important Notes:
-* This plugin supports terraform plan output with the terraform landscape gem, but there is currently a standalone plugin `TerraformLandscapePlugin` for this feature.
-* Note the `TerraformLandscapePlugin` does NOT contain support to post comments on pull requests.
-* If you desire BOTH terraform landscape output and comments on PR's, you should use the `TerraformPlanResultsPRPlugin` with `withLandscape(true)`
 
 ```
 @Library(['terraform-pipeline']) _
@@ -29,10 +19,8 @@ Jenkinsfile.init(this)
 // FOO/GITHUB_TOKEN will contain the respective username/password values of the 'my-cred' credential.
 CredentialsPlugin.withBuildCredentials([usernameVariable: 'FOO', passwordVariable: 'GITHUB_TOKEN'], 'my-cred').init()
 
-AnsiColorPlugin.init()                                    // Required when using 'withLandscape(true)' to colorize plan output
 TerraformPlanResultsPRPlugin.withRepoHost("https://api.github.com/")
                             .withRepoSlug("my-org/my-repo")
-                            .withLandscape(true)
                             .withGithubTokenEnvVar("GITHUB_TOKEN")
                             .init()
 

--- a/docs/TerraformPlanResultsPRPlugin.md
+++ b/docs/TerraformPlanResultsPRPlugin.md
@@ -3,6 +3,7 @@
 Use this to post Terraform plan results in the comments of a PR.
 
 One-Time Setup:
+* Your pipeline should be configured as a Multibranch Pipeline with Github Repository HTTPS URL.
 * Create a Github Personal Access Token that has permission to comment on your repo.  The default, the Github Personal Access Token is expected to be available in an environment variable `GITHUB_TOKEN`.  A number of [credential and configuration management plugins](https://github.com/manheim/terraform-pipeline#credentials-and-configuration-management) are available to do this.  Optionally, your Github Authentication token can be assigned to a different environment variable using `.withGithubTokenEnvVar(<different variable>)`
 
 ```

--- a/docs/TerraformPlanResultsPRPlugin.md
+++ b/docs/TerraformPlanResultsPRPlugin.md
@@ -2,27 +2,16 @@
 
 Use this to post Terraform plan results in the comments of a PR.
 
-Requirements:
-* Set the environment variable for Github Authentication. The default environment variable to be set is `GITHUB_TOKEN`. The CredentialsPlugin can help with setting this variable.
-
-Configuration Methods:
-* `withRepoHost(String)`: specify the Github source address (DEFAULT: "https://api.github.com/")
-* `withRepoSlug(String)`: specify the full repo slug (DEFAULT: "")
-* `withGithubTokenEnvVar(String)`: specify the environment variable used for github auth (DEFAULT: "GITHUB_TOKEN")
+One-Time Setup:
+* Create a Github Personal Access Token that has permission to comment on your repo.  The default, the Github Personal Access Token is expected to be available in an environment variable `GITHUB_TOKEN`.  A number of [credential and configuration management plugins](https://github.com/manheim/terraform-pipeline#credentials-and-configuration-management) are available to do this.  Optionally, your Github Authentication token can be assigned to a different environment variable using `.withGithubTokenEnvVar(<different variable>)`
 
 ```
 @Library(['terraform-pipeline']) _
 
 Jenkinsfile.init(this)
 
-// set GITHUB_TOKEN environment variable for use with TerraformPlanResultsPRPlugin
-// FOO/GITHUB_TOKEN will contain the respective username/password values of the 'my-cred' credential.
-CredentialsPlugin.withBuildCredentials([usernameVariable: 'FOO', passwordVariable: 'GITHUB_TOKEN'], 'my-cred').init()
-
-TerraformPlanResultsPRPlugin.withRepoHost("https://api.github.com/")
-                            .withRepoSlug("my-org/my-repo")
-                            .withGithubTokenEnvVar("GITHUB_TOKEN")
-                            .init()
+// A GITHUB_TOKEN environment variable should contain your Github PAT
+TerraformPlanResultsPRPlugin.init()
 
 def validate = new TerraformValidateStage()
 def deployQa = new TerraformEnvironmentStage('qa')

--- a/src/GithubPRPlanPlugin.groovy
+++ b/src/GithubPRPlanPlugin.groovy
@@ -2,7 +2,7 @@ import static TerraformEnvironmentStage.PLAN
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
-class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, TerraformEnvironmentStagePlugin {
+class GithubPRPlanPlugin implements TerraformPlanCommandPlugin, TerraformEnvironmentStagePlugin {
 
     private static String myRepoSlug
     private static String myRepoHost
@@ -10,14 +10,14 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
     private static final int MAX_COMMENT_LENGTH = 65535
 
     public static void init() {
-        TerraformPlanResultsPRPlugin plugin = new TerraformPlanResultsPRPlugin()
+        GithubPRPlanPlugin plugin = new GithubPRPlanPlugin()
 
         TerraformEnvironmentStage.addPlugin(plugin)
         TerraformPlanCommand.addPlugin(plugin)
     }
 
     public static withRepoSlug(String newRepoSlug) {
-        TerraformPlanResultsPRPlugin.myRepoSlug = newRepoSlug
+        GithubPRPlanPlugin.myRepoSlug = newRepoSlug
         return this
     }
 
@@ -27,7 +27,7 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
     }
 
     public static withGithubTokenEnvVar(String githubTokenEnvVar) {
-        TerraformPlanResultsPRPlugin.githubTokenEnvVar = githubTokenEnvVar
+        GithubPRPlanPlugin.githubTokenEnvVar = githubTokenEnvVar
         return this
     }
 

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -118,5 +118,6 @@ class Jenkinsfile {
 
     public static reset() {
         instance = new Jenkinsfile()
+        original = null
     }
 }

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -12,10 +12,14 @@ class Jenkinsfile {
             return repoSlug
         }
 
-        def scmUrl = getScmUrl()
-        def scmMap = parseScmUrl(scmUrl)
+        def scmMap = getParsedScmUrl()
         repoSlug = "${standardizeString(scmMap['organization'])}/${standardizeString(scmMap['repo'])}"
         return repoSlug
+    }
+
+    def Map getParsedScmUrl() {
+        def scmUrl = getScmUrl()
+        return parseScmUrl(scmUrl)
     }
 
     def String getScmUrl() {
@@ -27,10 +31,12 @@ class Jenkinsfile {
     }
 
     def Map parseScmUrl(String scmUrl) {
-        def matcher = scmUrl =~ /.*(?:\/\/|\@)[^\/:]+[\/:]([^\/]+)\/([^\/.]+)(.git)?/
+        def matcher = scmUrl =~ /(.*)(?::\/\/|\@)([^\/:]+)[\/:]([^\/]+)\/([^\/.]+)(.git)?/
         def Map results = [:]
-        results.put("organization", matcher[0][1])
-        results.put("repo", matcher[0][2])
+        results.put("protocol", matcher[0][1])
+        results.put("domain", matcher[0][2])
+        results.put("organization", matcher[0][3])
+        results.put("repo", matcher[0][4])
         return results
     }
 
@@ -39,12 +45,12 @@ class Jenkinsfile {
     }
 
     def String getRepoName() {
-        def Map scmMap = parseScmUrl(getScmUrl())
+        def Map scmMap = getParsedScmUrl()
         return scmMap['repo']
     }
 
     def String getOrganization() {
-        def Map scmMap = parseScmUrl(getScmUrl())
+        def Map scmMap = getParsedScmUrl()
         return scmMap['organization']
     }
 
@@ -104,5 +110,13 @@ class Jenkinsfile {
 
     public getEnv() {
         return original.env
+    }
+
+    public static withInstance(Jenkinsfile newInstance) {
+        this.instance = newInstance
+    }
+
+    public static reset() {
+        instance = new Jenkinsfile()
     }
 }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -10,6 +10,7 @@ class TerraformPlanCommand {
     private static plugins = DEFAULT_PLUGINS.clone()
     private appliedPlugins = []
     private String directory
+    private String errorFile
 
     public TerraformPlanCommand(String environment) {
         this.environment = environment
@@ -40,6 +41,11 @@ class TerraformPlanCommand {
         return this
     }
 
+    public TerraformPlanCommand withStandardErrorRedirection(String errorFile) {
+        this.errorFile = errorFile
+        return this
+    }
+
     public String toString() {
         applyPluginsOnce()
 
@@ -53,6 +59,12 @@ class TerraformPlanCommand {
         pieces += arguments
         if (directory) {
             pieces << directory
+        }
+
+        // This should be built out to handle more complex redirection
+        // and should be standardized across all TerraformCommands
+        if (errorFile) {
+            pieces << "2>${errorFile}"
         }
 
         pieces += suffixes

--- a/src/TerraformPlanResultsPRPlugin.groovy
+++ b/src/TerraformPlanResultsPRPlugin.groovy
@@ -7,6 +7,7 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
     private static String myRepoSlug
     private static String myRepoHost
     private static String githubTokenEnvVar = "GITHUB_TOKEN"
+    private static final int MAX_COMMENT_LENGTH = 65535
 
     public static void init() {
         TerraformPlanResultsPRPlugin plugin = new TerraformPlanResultsPRPlugin()
@@ -49,13 +50,8 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
             if (isPullRequest()) {
                 String commentBody = getCommentBody(env)
                 echo "Creating comment in GitHub"
-                def maxlen = 65535
-                def textlen = commentBody.length()
-                def chunk = "" // GitHub can't handle comments of 65536 or longer; chunk
-                def i = 0
-                for (i = 0; i < textlen; i += maxlen) {
-                    chunk = commentBody.substring(i, Math.min(textlen, i + maxlen))
-
+                // GitHub can't handle comments of 65536 or longer; chunk
+                commentBody.split("(?<=\\G.{${MAX_COMMENT_LENGTH}})").each { chunk ->
                     def data = JsonOutput.toJson([body: chunk])
                     def tmpDir = pwd(tmp: true)
                     def bodyPath = "${tmpDir}/body.txt"

--- a/src/TerraformPlanResultsPRPlugin.groovy
+++ b/src/TerraformPlanResultsPRPlugin.groovy
@@ -49,8 +49,7 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
         return { closure ->
             closure()
 
-            // comment on PR if this is a PR build
-            if (branch.startsWith("PR-")) {
+            if (isPullRequest()) {
                 String prNum = branch.replace('PR-', '')
                 // this reads "plan.out" and strips the ANSI color escapes, which look awful in github markdown
                 String planOutput = ''
@@ -119,6 +118,16 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
         def domain = parsedScmUrl['domain']
 
         return "${protocol}://${domain}"
+    }
+
+    public String getBranchName() {
+        return Jenkinsfile.instance.getEnv().BRANCH_NAME
+    }
+
+    public boolean isPullRequest() {
+        def branchName = getBranchName()
+
+        return branchName.startsWith('PR-')
     }
 
     public static void reset() {

--- a/src/TerraformPlanResultsPRPlugin.groovy
+++ b/src/TerraformPlanResultsPRPlugin.groovy
@@ -4,7 +4,6 @@ import groovy.json.JsonSlurper
 
 class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, TerraformEnvironmentStagePlugin {
 
-    private static boolean landscape = false
     private static String repoSlug = ""
     private static String repoHost = "https://api.github.com/"
     private static String githubTokenEnvVar = "GITHUB_TOKEN"
@@ -14,11 +13,6 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
 
         TerraformEnvironmentStage.addPlugin(plugin)
         TerraformPlanCommand.addPlugin(plugin)
-    }
-
-    public static withLandscape(boolean landscape) {
-        TerraformPlanResultsPRPlugin.landscape = landscape
-        return this
     }
 
     public static withRepoSlug(String repoSlug) {
@@ -43,14 +37,9 @@ class TerraformPlanResultsPRPlugin implements TerraformPlanCommandPlugin, Terraf
 
     @Override
     public void apply(TerraformPlanCommand command) {
-        if (landscape) {
-            command.withArgument("-out=tfplan")
-            command.withSuffix("2>plan.err | landscape | tee plan.out")
-        }
-        else {
-            command.withArgument("-out=tfplan")
-            command.withSuffix("2>plan.err | tee plan.out")
-        }
+        command.withArgument("-out=tfplan")
+        command.withStandardErrorRedirection('plan.err')
+        command.withSuffix('| tee plan.out')
     }
 
     public static Closure addComment(String env) {

--- a/test/DummyJenkinsfile.groovy
+++ b/test/DummyJenkinsfile.groovy
@@ -15,4 +15,10 @@ class DummyJenkinsfile {
         return this
     }
     public build(String image, String options) { return this }
+    public echo(String message) { println "DummyJenkinsfile.echo ${message}" }
+    public pwd(Map options) { return '/DummyJenkinsfile/currentDir' }
+    public writeFile(Map options) { println "DummyJenkinsfile.writeFile: ${options.toString()}" }
+    public readFile(String filename) { return "Dummyjenkinsfile.readFile(${filename}): some content" }
+    public fileExists(String filename) { return false }
+    public sh(Map options) { println "DummyJenkinsfile.sh: ${options.toString()}"; return 'DummyJenkinsfile.sh output' }
 }

--- a/test/GithubPRPlanPlugin.groovy
+++ b/test/GithubPRPlanPlugin.groovy
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
-class TerraformPlanResultsPRPluginTest {
+class GithubPRPlanPluginTest {
 
     @Before
     void resetJenkinsEnv() {
@@ -47,18 +47,18 @@ class TerraformPlanResultsPRPluginTest {
 
         @Test
         void modifiesTerraformPlanCommand() {
-            TerraformPlanResultsPRPlugin.init()
+            GithubPRPlanPlugin.init()
 
             Collection actualPlugins = TerraformPlanCommand.getPlugins()
-            assertThat(actualPlugins, hasItem(instanceOf(TerraformPlanResultsPRPlugin.class)))
+            assertThat(actualPlugins, hasItem(instanceOf(GithubPRPlanPlugin.class)))
         }
 
         @Test
         void modifiesTerraformEnvironmentStageCommand() {
-            TerraformPlanResultsPRPlugin.init()
+            GithubPRPlanPlugin.init()
 
             Collection actualPlugins = TerraformEnvironmentStage.getPlugins()
-            assertThat(actualPlugins, hasItem(instanceOf(TerraformPlanResultsPRPlugin.class)))
+            assertThat(actualPlugins, hasItem(instanceOf(GithubPRPlanPlugin.class)))
         }
     }
 
@@ -66,7 +66,7 @@ class TerraformPlanResultsPRPluginTest {
 
         @Test
         void addsTeeArgumentToTerraformPlan() {
-            TerraformPlanResultsPRPlugin plugin = new TerraformPlanResultsPRPlugin()
+            GithubPRPlanPlugin plugin = new GithubPRPlanPlugin()
             TerraformPlanCommand command = new TerraformPlanCommand()
 
             plugin.apply(command)
@@ -78,7 +78,7 @@ class TerraformPlanResultsPRPluginTest {
 
         @Test
         void decoratesTheTerraformEnvironmentStage()  {
-            TerraformPlanResultsPRPlugin plugin = new TerraformPlanResultsPRPlugin()
+            GithubPRPlanPlugin plugin = new GithubPRPlanPlugin()
             def environment = spy(new TerraformEnvironmentStage())
             configureJenkins(env: [
                 'BRANCH_NAME': 'master',
@@ -95,15 +95,15 @@ class TerraformPlanResultsPRPluginTest {
     class GetRepoSlug {
         @After
         void resetPlugin() {
-            TerraformPlanResultsPRPlugin.reset()
+            GithubPRPlanPlugin.reset()
             Jenkinsfile.reset()
         }
 
         @Test
         void returnsTheProvidedRepoSlug() {
             String expectedSlug = 'some/slug'
-            TerraformPlanResultsPRPlugin.withRepoSlug(expectedSlug)
-            def plugin = new TerraformPlanResultsPRPlugin()
+            GithubPRPlanPlugin.withRepoSlug(expectedSlug)
+            def plugin = new GithubPRPlanPlugin()
 
             String actualSlug = plugin.getRepoSlug()
 
@@ -117,7 +117,7 @@ class TerraformPlanResultsPRPluginTest {
             def jenkinsfileInstance = mock(Jenkinsfile.class)
             doReturn([organization: expectedOrg, repo: expectedRepo]).when(jenkinsfileInstance).getParsedScmUrl()
             Jenkinsfile.withInstance(jenkinsfileInstance)
-            def plugin = new TerraformPlanResultsPRPlugin()
+            def plugin = new GithubPRPlanPlugin()
 
             String actualSlug = plugin.getRepoSlug()
 
@@ -129,21 +129,21 @@ class TerraformPlanResultsPRPluginTest {
     class GetRepoHost {
         @Before
         void resetBefore() {
-            TerraformPlanResultsPRPlugin.reset()
+            GithubPRPlanPlugin.reset()
             Jenkinsfile.reset()
         }
 
         @After
         void reset() {
-            TerraformPlanResultsPRPlugin.reset()
+            GithubPRPlanPlugin.reset()
             Jenkinsfile.reset()
         }
 
         @Test
         void returnsTheProvidedHost() {
             String expectedHost = 'somehost'
-            TerraformPlanResultsPRPlugin.withRepoHost(expectedHost)
-            def plugin = new TerraformPlanResultsPRPlugin()
+            GithubPRPlanPlugin.withRepoHost(expectedHost)
+            def plugin = new GithubPRPlanPlugin()
 
             String actualHost = plugin.getRepoHost()
 
@@ -152,7 +152,7 @@ class TerraformPlanResultsPRPluginTest {
 
         @Test
         void defaultsToTheHostOfTheProject() {
-            def plugin = new TerraformPlanResultsPRPlugin()
+            def plugin = new GithubPRPlanPlugin()
             def jenkinsfileInstance = mock(Jenkinsfile.class)
             doReturn([protocol: 'https', domain: 'my.github.com']).when(jenkinsfileInstance).getParsedScmUrl()
             Jenkinsfile.withInstance(jenkinsfileInstance)
@@ -164,7 +164,7 @@ class TerraformPlanResultsPRPluginTest {
 
         @Test
         void defaultsToTheProtocolOfTheProject() {
-            def plugin = new TerraformPlanResultsPRPlugin()
+            def plugin = new GithubPRPlanPlugin()
             def jenkinsfileInstance = mock(Jenkinsfile.class)
             doReturn([protocol: 'http', domain: 'my.github.com']).when(jenkinsfileInstance).getParsedScmUrl()
             Jenkinsfile.withInstance(jenkinsfileInstance)
@@ -178,7 +178,7 @@ class TerraformPlanResultsPRPluginTest {
     class IsPullRequest {
         @Test
         void returnsTrueWhenBranchNameStartsWithPR() {
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn('PR-thisIsAPullRequest').when(plugin).getBranchName()
 
             assertTrue(plugin.isPullRequest())
@@ -186,7 +186,7 @@ class TerraformPlanResultsPRPluginTest {
 
         @Test
         void returnsfalseWhenBranchNameDoesNotStartWithPR() {
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn('ThisIsNotA-PR').when(plugin).getBranchName()
 
             assertFalse(plugin.isPullRequest())
@@ -198,7 +198,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void parsesTheNumberFromTheBranchName() {
             def expectedNumber = "123"
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn("PR-${expectedNumber}".toString()).when(plugin).getBranchName()
 
             def actualNumber = plugin.getPullRequestNumber()
@@ -213,7 +213,7 @@ class TerraformPlanResultsPRPluginTest {
             def repoHost = 'someHost'
             def repoSlug = 'someSlug'
             def pullRequestNumber = 'somePr'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn(repoHost).when(plugin).getRepoHost()
             doReturn(repoSlug).when(plugin).getRepoSlug()
             doReturn(pullRequestNumber).when(plugin).getPullRequestNumber()
@@ -228,7 +228,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void readsContentsFromPlanOutFile() {
             def planOutFileContent = 'blahblahblah'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn(planOutFileContent).when(plugin).readFile('plan.out')
             doReturn(null).when(plugin).readFile('plan.err')
 
@@ -240,7 +240,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void stripsWhitespaceEncodingFromContentsFromPlanOutFile() {
             def expectedOutput = 'blahblah'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn("   ${expectedOutput}   ".toString()).when(plugin).readFile('plan.out')
             doReturn(null).when(plugin).readFile('plan.err')
 
@@ -252,7 +252,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void stripsAnsiColorEncodingFromContentsFromPlanOutFile() {
             def colorEncoding = '\u001b[32m'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn("${colorEncoding}blablah${colorEncoding}".toString()).when(plugin).readFile('plan.out')
             doReturn(null).when(plugin).readFile('plan.err')
 
@@ -265,7 +265,7 @@ class TerraformPlanResultsPRPluginTest {
             @Test
             void includesContentsFromPlanErrorFileIfPresent() {
                 def planErrorFileContent = 'errorcontent'
-                def plugin = spy(new TerraformPlanResultsPRPlugin())
+                def plugin = spy(new GithubPRPlanPlugin())
                 doReturn('blahblah').when(plugin).readFile('plan.out')
                 doReturn(planErrorFileContent).when(plugin).readFile('plan.err')
 
@@ -278,7 +278,7 @@ class TerraformPlanResultsPRPluginTest {
             void stripsWhitespaceFromContentsFromPlanErrorFile() {
                 def planOutput = 'planOut'
                 def planError = 'planError'
-                def plugin = spy(new TerraformPlanResultsPRPlugin())
+                def plugin = spy(new GithubPRPlanPlugin())
                 doReturn(planOutput).when(plugin).readFile('plan.out')
                 doReturn("   ${planError}   ".toString()).when(plugin).readFile('plan.err')
 
@@ -290,7 +290,7 @@ class TerraformPlanResultsPRPluginTest {
             @Test
             void stripsAnsiColorEncodingFromContentsFromPlanErrorFile() {
                 def colorEncoding = '\u001b[32m'
-                def plugin = spy(new TerraformPlanResultsPRPlugin())
+                def plugin = spy(new GithubPRPlanPlugin())
                 doReturn('planOut').when(plugin).readFile('plan.out')
                 doReturn("${colorEncoding}blablah${colorEncoding}".toString()).when(plugin).readFile('plan.err')
 
@@ -303,7 +303,7 @@ class TerraformPlanResultsPRPluginTest {
             void ignoresPlanErrorFileContentIfEmpty() {
                 def planOutput = 'planOut'
                 def planError = ''
-                def plugin = spy(new TerraformPlanResultsPRPlugin())
+                def plugin = spy(new GithubPRPlanPlugin())
                 doReturn(planOutput).when(plugin).readFile('plan.out')
                 doReturn(planError).when(plugin).readFile('plan.err')
 
@@ -318,7 +318,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void usesThePlanOutput()  {
             def planOutput = 'someOutput'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn(planOutput).when(plugin).getPlanOutput()
             doReturn('someResult').when(plugin).getBuildResult()
             doReturn('someUrl').when(plugin).getBuildUrl()
@@ -331,7 +331,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void usesTheCurrentBuildResult()  {
             def expectedBuildResult = 'expectedResult'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn('someOutput').when(plugin).getPlanOutput()
             doReturn(expectedBuildResult).when(plugin).getBuildResult()
             doReturn('someUrl').when(plugin).getBuildUrl()
@@ -344,7 +344,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void usesTheCurrentBuildUrl()  {
             def expectedBuildUrl = 'expectedBuildUrl'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn('someOutput').when(plugin).getPlanOutput()
             doReturn('someResult').when(plugin).getBuildResult()
             doReturn(expectedBuildUrl).when(plugin).getBuildUrl()
@@ -357,7 +357,7 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void usesTheGivenEnvironment()  {
             def expectedEnvironment = 'expectedEnv'
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn('someOutput').when(plugin).getPlanOutput()
             doReturn('someResult').when(plugin).getBuildResult()
             doReturn('someUrl').when(plugin).getBuildUrl()
@@ -382,7 +382,7 @@ class TerraformPlanResultsPRPluginTest {
         // This needs to be tested better than 'do not blow up'
         @Test
         void doesNotBlowUp() {
-            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            def plugin = spy(new GithubPRPlanPlugin())
             doReturn('HTTP/1.1 201 Created').when(plugin).readFile('comment.headers')
             doReturn('{ "id": "someId", "html_url": "some_url" }').when(Jenkinsfile.original).sh(anyObject())
 

--- a/test/JenkinsfileTest.groovy
+++ b/test/JenkinsfileTest.groovy
@@ -25,7 +25,7 @@ class JenkinsfileTest {
                     String organization = "MyOrg"
                     Map results = jenkinsfile.parseScmUrl("http://my.github.com/${organization}/SomeRepo.git")
 
-                    assertEquals(results['organization'], organization)
+                    assertEquals(organization, results['organization'])
                 }
 
                 @Test
@@ -33,7 +33,23 @@ class JenkinsfileTest {
                     String repo = "MyRepo"
                     Map results = jenkinsfile.parseScmUrl("http://my.github.com/SomeOrg/${repo}.git")
 
-                    assertEquals(results['repo'], repo)
+                    assertEquals(repo, results['repo'])
+                }
+
+                @Test
+                void returnsBaseUrl() {
+                    String expectedDomain = "my.github.com"
+                    Map results = jenkinsfile.parseScmUrl("http://${expectedDomain}/SomeOrg/SomeRepo.git")
+
+                    assertEquals(expectedDomain, results['domain'])
+                }
+
+                @Test
+                void returnsTheProtocolUsed() {
+                    String expectedProtocol = "http"
+                    Map results = jenkinsfile.parseScmUrl("${expectedProtocol}://my.github.com/SomeOrg/SomeRepo.git")
+
+                    assertEquals(expectedProtocol, results['protocol'])
                 }
             }
 
@@ -43,7 +59,7 @@ class JenkinsfileTest {
                     String organization = "MyOrg"
                     Map results = jenkinsfile.parseScmUrl("https://my.github.com/${organization}/SomeRepo.git")
 
-                    assertEquals(results['organization'], organization)
+                    assertEquals(organization, results['organization'])
                 }
 
                 @Test
@@ -51,7 +67,23 @@ class JenkinsfileTest {
                     String repo = "MyRepo"
                     Map results = jenkinsfile.parseScmUrl("https://my.github.com/SomeOrg/${repo}.git")
 
-                    assertEquals(results['repo'], repo)
+                    assertEquals(repo, results['repo'])
+                }
+
+                @Test
+                void returnsDomain() {
+                    String expectedDomain = "my.github.com"
+                    Map results = jenkinsfile.parseScmUrl("https://${expectedDomain}/SomeOrg/SomeRepo.git")
+
+                    assertEquals(expectedDomain, results['domain'])
+                }
+
+                @Test
+                void returnsTheProtocolUsed() {
+                    String expectedProtocol = "https"
+                    Map results = jenkinsfile.parseScmUrl("${expectedProtocol}://my.github.com/SomeOrg/SomeRepo.git")
+
+                    assertEquals(expectedProtocol, results['protocol'])
                 }
             }
         }
@@ -62,7 +94,7 @@ class JenkinsfileTest {
                 String organization = "MyOrg"
                 Map results = jenkinsfile.parseScmUrl("git@my.github.com:${organization}/SomeRepo.git")
 
-                assertEquals(results['organization'], organization)
+                assertEquals(organization, results['organization'])
             }
 
             @Test
@@ -70,7 +102,23 @@ class JenkinsfileTest {
                 String repo = "MyRepo"
                 Map results = jenkinsfile.parseScmUrl("git@my.github.com:SomeOrg/${repo}.git")
 
-                assertEquals(results['repo'], repo)
+                assertEquals(repo, results['repo'])
+            }
+
+            @Test
+            void returnsDomain() {
+                String expectedDomain = "my.github.com"
+                Map results = jenkinsfile.parseScmUrl("git@${expectedDomain}/SomeOrg/SomeRepo.git")
+
+                assertEquals(expectedDomain, results['domain'])
+            }
+
+            @Test
+            void returnsTheProtocolUsed() {
+                String expectedProtocol = 'git'
+                Map results = jenkinsfile.parseScmUrl("${expectedProtocol}@my.github.com/SomeOrg/SomeRepo.git")
+
+                assertEquals(expectedProtocol, results['protocol'])
             }
         }
     }
@@ -96,7 +144,7 @@ class JenkinsfileTest {
             Jenkinsfile.defaultNodeName = expectedName
 
             String actualName = Jenkinsfile.getNodeName()
-            assertEquals(actualName, expectedName)
+            assertEquals(expectedName, actualName)
         }
 
         @Test
@@ -106,7 +154,7 @@ class JenkinsfileTest {
             configureJenkins(env: [ DEFAULT_NODE_NAME: 'wrongName' ])
 
             String actualName = Jenkinsfile.getNodeName()
-            assertEquals(actualName, expectedName)
+            assertEquals(expectedName, actualName)
         }
 
         @Test
@@ -116,7 +164,7 @@ class JenkinsfileTest {
             configureJenkins(env: [ DEFAULT_NODE_NAME: expectedName ])
 
             String actualName = Jenkinsfile.getNodeName()
-            assertEquals(actualName, expectedName)
+            assertEquals(expectedName, actualName)
         }
     }
 }

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -3,6 +3,7 @@ import static org.hamcrest.Matchers.endsWith
 import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.startsWith
 import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
@@ -114,6 +115,36 @@ class TerraformPlanCommandTest {
             def actualCommand = command.toString()
             assertThat(actualCommand, containsString(" foo"))
             assertThat(actualCommand, containsString(" bar"))
+        }
+    }
+
+    public class WithStandardErrorRedirection {
+        @Test
+        void sendsStandardErrorToTheGivenFile() {
+            def command = new TerraformPlanCommand().withStandardErrorRedirection('error.txt')
+
+            def actualCommand = command.toString()
+
+            assertThat(actualCommand, containsString("2>error.txt"))
+        }
+
+        @Test
+        void comesBeforeSuffix() {
+            def command = new TerraformPlanCommand()
+            command.withSuffix('| xargs echo')
+                   .withStandardErrorRedirection('error.txt')
+
+            def actualCommand = command.toString()
+
+            assertThat(actualCommand, containsString("2>error.txt | xargs echo"))
+        }
+
+        @Test
+        void isFluent() {
+            def expectedCommand = new TerraformPlanCommand()
+            def actualCommand = expectedCommand.withStandardErrorRedirection('error.txt')
+
+            assertTrue(expectedCommand == actualCommand)
         }
     }
 

--- a/test/TerraformPlanResultsPRPluginTest.groovy
+++ b/test/TerraformPlanResultsPRPluginTest.groovy
@@ -2,7 +2,9 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -168,5 +170,24 @@ class TerraformPlanResultsPRPluginTest {
 
             assertEquals('http://my.github.com', actualHost)
         }
+    }
+
+    class IsPullRequest {
+        @Test
+        void returnsTrueWhenBranchNameStartsWithPR() {
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn('PR-thisIsAPullRequest').when(plugin).getBranchName()
+
+            assertTrue(plugin.isPullRequest())
+        }
+
+        @Test
+        void returnsfalseWhenBranchNameDoesNotStartWithPR() {
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn('ThisIsNotA-PR').when(plugin).getBranchName()
+
+            assertFalse(plugin.isPullRequest())
+        }
+
     }
 }

--- a/test/TerraformPlanResultsPRPluginTest.groovy
+++ b/test/TerraformPlanResultsPRPluginTest.groovy
@@ -190,4 +190,34 @@ class TerraformPlanResultsPRPluginTest {
         }
 
     }
+
+    class GetPullRequestNumber {
+        @Test
+        void parsesTheNumberFromTheBranchName() {
+            def expectedNumber = "123"
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn("PR-${expectedNumber}".toString()).when(plugin).getBranchName()
+
+            def actualNumber = plugin.getPullRequestNumber()
+
+            assertEquals(expectedNumber, actualNumber)
+        }
+    }
+
+    class GetPullRequestCommentUrl {
+        @Test
+        void constructsTheUrlFromHostRepoSlugAndPrNumber() {
+            def repoHost = 'someHost'
+            def repoSlug = 'someSlug'
+            def pullRequestNumber = 'somePr'
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn(repoHost).when(plugin).getRepoHost()
+            doReturn(repoSlug).when(plugin).getRepoSlug()
+            doReturn(pullRequestNumber).when(plugin).getPullRequestNumber()
+
+            def commentUrl = plugin.getPullRequestCommentUrl()
+
+            assertEquals("${repoHost}/api/v3/repos/${repoSlug}/issues/${pullRequestNumber}/comments".toString(), commentUrl)
+        }
+    }
 }

--- a/test/TerraformPlanResultsPRPluginTest.groovy
+++ b/test/TerraformPlanResultsPRPluginTest.groovy
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static TerraformEnvironmentStage.PLAN;
@@ -365,5 +366,33 @@ class TerraformPlanResultsPRPluginTest {
 
             assertThat(actualComment, containsString(expectedEnvironment))
         }
+    }
+
+    class PostPullRequestComment {
+        @After
+        void reset() {
+            Jenkinsfile.reset()
+        }
+
+        @Before
+        void stubJenkins() {
+            Jenkinsfile.original = spy(new DummyJenkinsfile())
+        }
+
+        // This needs to be tested better than 'do not blow up'
+        @Test
+        void doesNotBlowUp() {
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn('HTTP/1.1 201 Created').when(plugin).readFile('comment.headers')
+            doReturn('{ "id": "someId", "html_url": "some_url" }').when(Jenkinsfile.original).sh(anyObject())
+
+            plugin.postPullRequestComment('someUrl', 'myPrComment')
+        }
+
+        // Test executes passed closure
+        // Test raises error on non HTTP/1.1 201 Created
+        // Uses the correct pullRequestUrl
+        // Uses the correct git auth token
+        // Chunks requests correct if over 65536
     }
 }

--- a/test/TerraformPlanResultsPRPluginTest.groovy
+++ b/test/TerraformPlanResultsPRPluginTest.groovy
@@ -312,4 +312,58 @@ class TerraformPlanResultsPRPluginTest {
             }
         }
     }
+
+    class GetCommentBody {
+        @Test
+        void usesThePlanOutput()  {
+            def planOutput = 'someOutput'
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn(planOutput).when(plugin).getPlanOutput()
+            doReturn('someResult').when(plugin).getBuildResult()
+            doReturn('someUrl').when(plugin).getBuildUrl()
+
+            def actualComment = plugin.getCommentBody('myenv')
+
+            assertThat(actualComment, containsString(planOutput))
+        }
+
+        @Test
+        void usesTheCurrentBuildResult()  {
+            def expectedBuildResult = 'expectedResult'
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn('someOutput').when(plugin).getPlanOutput()
+            doReturn(expectedBuildResult).when(plugin).getBuildResult()
+            doReturn('someUrl').when(plugin).getBuildUrl()
+
+            def actualComment = plugin.getCommentBody('myenv')
+
+            assertThat(actualComment, containsString(expectedBuildResult))
+        }
+
+        @Test
+        void usesTheCurrentBuildUrl()  {
+            def expectedBuildUrl = 'expectedBuildUrl'
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn('someOutput').when(plugin).getPlanOutput()
+            doReturn('someResult').when(plugin).getBuildResult()
+            doReturn(expectedBuildUrl).when(plugin).getBuildUrl()
+
+            def actualComment = plugin.getCommentBody('myenv')
+
+            assertThat(actualComment, containsString(expectedBuildUrl))
+        }
+
+        @Test
+        void usesTheGivenEnvironment()  {
+            def expectedEnvironment = 'expectedEnv'
+            def plugin = spy(new TerraformPlanResultsPRPlugin())
+            doReturn('someOutput').when(plugin).getPlanOutput()
+            doReturn('someResult').when(plugin).getBuildResult()
+            doReturn('someUrl').when(plugin).getBuildUrl()
+
+            def actualComment = plugin.getCommentBody(expectedEnvironment)
+
+            assertThat(actualComment, containsString(expectedEnvironment))
+        }
+    }
 }

--- a/test/TerraformPlanResultsPRPluginTest.groovy
+++ b/test/TerraformPlanResultsPRPluginTest.groovy
@@ -60,25 +60,13 @@ class TerraformPlanResultsPRPluginTest {
         @Test
         void addsTeeArgumentToTerraformPlan() {
             TerraformPlanResultsPRPlugin plugin = new TerraformPlanResultsPRPlugin()
-            plugin.withLandscape(false)
             TerraformPlanCommand command = new TerraformPlanCommand()
 
             plugin.apply(command)
 
             String result = command.toString()
-            assertThat(result, containsString(" -out=tfplan 2>plan.err | tee plan.out"))
-        }
-
-        @Test
-        void addsTeeAndLandscapeArgumentToTerraformPlan() {
-            TerraformPlanResultsPRPlugin plugin = new TerraformPlanResultsPRPlugin()
-            plugin.withLandscape(true)
-            TerraformPlanCommand command = new TerraformPlanCommand()
-
-            plugin.apply(command)
-
-            String result = command.toString()
-            assertThat(result, containsString(" -out=tfplan 2>plan.err | landscape | tee plan.out"))
+            assertThat(result, containsString("-out=tfplan"))
+            assertThat(result, containsString("2>plan.err | tee plan.out"))
         }
 
         @Test


### PR DESCRIPTION
* More for Issue #193 
* Repo slug can be constructed from the scm URL
* The base URL can be constructed from the scm URL
* Remove landscape functionality from the plugin - there's a separate Landscape plugin