### PR TITLE
Issue 261: Require user to type in confirmation for destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #261](https://github.com/manheim/terraform-pipeline/issues/261) Require the user to type a confirmation to use the DestroyPlugin
 * [Issue #275](https://github.com/manheim/terraform-pipeline/issues/275) Alphabetize Plugins in the README
 * [Issue #272](https://github.com/manheim/terraform-pipeline/issues/272) Create a new BuildWithParametersPlugin
 * [Issue #256](https://github.com/manheim/terraform-pipeline/issues/256) Make it easy to apply "standard tags"

--- a/src/ConfirmApplyPlugin.groovy
+++ b/src/ConfirmApplyPlugin.groovy
@@ -2,6 +2,7 @@ import static TerraformEnvironmentStage.CONFIRM
 
 class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin {
 
+    public static parameters = []
     public static enabled = true
     public static String confirmMessage = 'Are you absolutely sure the plan above is correct, and should be IMMEDIATELY DEPLOYED via "terraform apply"?'
     public static String okMessage = 'Run terraform apply now'
@@ -21,22 +22,36 @@ class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin {
         }
     }
 
-    public static Closure addConfirmation() {
+    public Closure addConfirmation() {
         return { closure ->
             // ask for human input
             try {
                 timeout(time: 15, unit: 'MINUTES') {
-                    input(
-                        message: confirmMessage,
-                        ok: okMessage,
-                        submitterParameter: submitter
-                    )
+                    input(getInputOptions())
                 }
             } catch (ex) {
                 throw ex
             }
             closure()
         }
+    }
+
+    private Map getInputOptions() {
+        Map inputOptions = [
+            message: confirmMessage,
+            ok: okMessage,
+            submitterParameter: submitter
+        ]
+
+        if (!parameters.isEmpty()) {
+            inputOptions['parameters'] = parameters
+        }
+
+        return inputOptions
+    }
+
+    public static void withParameter(Map parameterOptions) {
+        parameters << parameterOptions
     }
 
     public static void withConfirmMessage(String newMessage) {
@@ -59,5 +74,10 @@ class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin {
     public static enable() {
         this.enabled = true
         return this
+    }
+
+    public static reset() {
+        this.enabled = true
+        this.parameters = []
     }
 }

--- a/src/ConfirmApplyPlugin.groovy
+++ b/src/ConfirmApplyPlugin.groovy
@@ -2,12 +2,13 @@ import static TerraformEnvironmentStage.CONFIRM
 
 class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin {
 
+    public static final String DEFAULT_SUBMITTER_PARAMETER = 'approver'
     public static parameters = []
     public static confirmConditions = []
     public static enabled = true
     public static String confirmMessage = 'Are you absolutely sure the plan above is correct, and should be IMMEDIATELY DEPLOYED via "terraform apply"?'
     public static String okMessage = 'Run terraform apply now'
-    public static String submitter = 'approver'
+    public static String submitter
 
     public static void init() {
         TerraformEnvironmentStage.addPlugin(new ConfirmApplyPlugin())
@@ -40,7 +41,7 @@ class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin {
         Map inputOptions = interpolateMap([
             message: confirmMessage,
             ok: okMessage,
-            submitterParameter: submitter
+            submitterParameter: submitter ?: DEFAULT_SUBMITTER_PARAMETER
         ], environment)
 
         if (!parameters.isEmpty()) {
@@ -76,20 +77,24 @@ class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin {
         return this
     }
 
-    public static void withParameter(Map parameterOptions) {
+    public static withParameter(Map parameterOptions) {
         parameters << parameterOptions
+        return this
     }
 
-    public static void withConfirmMessage(String newMessage) {
+    public static withConfirmMessage(String newMessage) {
         this.confirmMessage = newMessage
+        return this
     }
 
-    public static void withOkMessage(String newMessage) {
+    public static withOkMessage(String newMessage) {
         this.okMessage = newMessage
+        return this
     }
 
-    public static void withSubmitterParameter(String newParam) {
-        this.submitterParameter = newParam
+    public static withSubmitterParameter(String newParam) {
+        this.submitter = newParam
+        return this
     }
 
     public static disable() {
@@ -106,5 +111,6 @@ class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin {
         this.enabled = true
         this.parameters = []
         this.confirmConditions = []
+        this.submitter = null
     }
 }

--- a/src/DestroyPlugin.groovy
+++ b/src/DestroyPlugin.groovy
@@ -18,7 +18,7 @@ class DestroyPlugin implements TerraformPlanCommandPlugin,
                 description: "Type \"destroy ${appName} \${environment}\" to confirm and continue."
             ])
         ConfirmApplyPlugin.withConfirmCondition { options ->
-            "destroy ${appName} ${options['environment']}".toString().equals(options['input']['CONFIRM_DESTROY'])
+            "destroy ${appName} ${options['environment']}".toString() == options['input']['CONFIRM_DESTROY']
         }
 
         TerraformEnvironmentStage.withStageNamePattern { options -> "${options['command']}-DESTROY-${options['environment']}" }

--- a/src/DestroyPlugin.groovy
+++ b/src/DestroyPlugin.groovy
@@ -17,9 +17,7 @@ class DestroyPlugin implements TerraformPlanCommandPlugin,
                 name: 'CONFIRM_DESTROY',
                 description: "Type \"destroy ${appName} \${environment}\" to confirm and continue."
             ])
-        ConfirmApplyPlugin.withConfirmCondition { options ->
-            "destroy ${appName} ${options['environment']}".toString() == options['input']['CONFIRM_DESTROY']
-        }
+        ConfirmApplyPlugin.withConfirmCondition(getConfirmCondition(appName))
 
         TerraformEnvironmentStage.withStageNamePattern { options -> "${options['command']}-DESTROY-${options['environment']}" }
 
@@ -41,6 +39,12 @@ class DestroyPlugin implements TerraformPlanCommandPlugin,
     public static withArgument(String arg) {
         arguments << arg
         return this
+    }
+
+    public static getConfirmCondition(String appName) {
+        return { options ->
+            "destroy ${appName} ${options['environment']}".toString() == options['input']['CONFIRM_DESTROY']
+        }
     }
 
     public static reset() {

--- a/src/DestroyPlugin.groovy
+++ b/src/DestroyPlugin.groovy
@@ -2,14 +2,22 @@ class DestroyPlugin implements TerraformPlanCommandPlugin,
                                TerraformApplyCommandPlugin {
 
     private static arguments = []
-    public static DESTROY_CONFIRM_MESSAGE = 'WARNING! Are you absolutely sure the plan above is correct? Your environment will be IMMEDIATELY DESTROYED via "terraform destroy"'
+    public static DESTROY_CONFIRM_MESSAGE = 'DANGER! Your ${environment} environment will be IMMEDIATELY DESTROYED via "terraform destroy".  Review your plan to see all the resources that will be destroyed, and confirm. YOU CANNOT UNDO THIS.'
     public static DESTROY_OK_MESSAGE = "Run terraform DESTROY now"
 
     public static void init() {
         DestroyPlugin plugin = new DestroyPlugin()
 
+        def appName = Jenkinsfile.instance.getRepoName()
+
         ConfirmApplyPlugin.withConfirmMessage(DESTROY_CONFIRM_MESSAGE)
         ConfirmApplyPlugin.withOkMessage(DESTROY_OK_MESSAGE)
+        ConfirmApplyPlugin.withParameter([
+                $class: 'hudson.model.StringParameterDefinition',
+                name: 'CONFIRM_DESTROY',
+                description: "Type \"destroy ${appName} \${environment}\" to confirm and continue."
+            ])
+
         TerraformEnvironmentStage.withStageNamePattern { options -> "${options['command']}-DESTROY-${options['environment']}" }
 
         TerraformPlanCommand.addPlugin(plugin)

--- a/src/DestroyPlugin.groovy
+++ b/src/DestroyPlugin.groovy
@@ -17,6 +17,9 @@ class DestroyPlugin implements TerraformPlanCommandPlugin,
                 name: 'CONFIRM_DESTROY',
                 description: "Type \"destroy ${appName} \${environment}\" to confirm and continue."
             ])
+        ConfirmApplyPlugin.withConfirmCondition { options ->
+            "destroy ${appName} ${options['environment']}".toString().equals(options['input']['CONFIRM_DESTROY'])
+        }
 
         TerraformEnvironmentStage.withStageNamePattern { options -> "${options['command']}-DESTROY-${options['environment']}" }
 

--- a/test/ConfirmApplyPluginTest.groovy
+++ b/test/ConfirmApplyPluginTest.groovy
@@ -1,6 +1,7 @@
 import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertThat
@@ -44,7 +45,7 @@ class ConfirmApplyPluginTest {
         void defaultsToNoExtraParameters() {
             def plugin = new ConfirmApplyPlugin()
 
-            def parameters = plugin.getInputOptions()['parameters']
+            def parameters = plugin.getInputOptions('env')['parameters']
 
             assertNull(parameters)
         }
@@ -55,9 +56,34 @@ class ConfirmApplyPluginTest {
             def plugin = new ConfirmApplyPlugin()
             ConfirmApplyPlugin.withParameter(expectedParameter)
 
-            def parameters = plugin.getInputOptions()['parameters']
+            def parameters = plugin.getInputOptions('env')['parameters']
 
             assertThat(parameters, contains(expectedParameter))
+        }
+
+        @Test
+        void interpolatesEnvironmentVariableInConfirmMessage() {
+            def environment = 'foo'
+            def plugin = new ConfirmApplyPlugin()
+            ConfirmApplyPlugin.withConfirmMessage('confirm for ${environment}')
+
+            def message = plugin.getInputOptions(environment)['message']
+
+            assertEquals("confirm for foo", message)
+        }
+
+        @Test
+        void interpolatesEnvironmentVariableInAddParameters() {
+            def environment = 'foo'
+            def plugin = new ConfirmApplyPlugin()
+            ConfirmApplyPlugin.withParameter([
+                name: 'confirm',
+                description: 'confirm for ${environment}'
+            ])
+
+            def description = plugin.getInputOptions(environment)['parameters'][0]['description']
+
+            assertEquals("confirm for foo", description)
         }
     }
 }

--- a/test/ConfirmApplyPluginTest.groovy
+++ b/test/ConfirmApplyPluginTest.groovy
@@ -1,6 +1,8 @@
+import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertTrue
 
@@ -13,7 +15,7 @@ import de.bechte.junit.runners.context.HierarchicalContextRunner
 class ConfirmApplyPluginTest {
     @After
     void reset() {
-        ConfirmApplyPlugin.enabled = true
+        ConfirmApplyPlugin.reset()
     }
 
     @Test
@@ -35,6 +37,28 @@ class ConfirmApplyPluginTest {
         ConfirmApplyPlugin.disable()
 
         assertFalse(ConfirmApplyPlugin.enabled)
+    }
+
+    class GetInputOptions {
+        @Test
+        void defaultsToNoExtraParameters() {
+            def plugin = new ConfirmApplyPlugin()
+
+            def parameters = plugin.getInputOptions()['parameters']
+
+            assertNull(parameters)
+        }
+
+        @Test
+        void addsTheParameterToConfirmationInputOptions() {
+            def expectedParameter = ['someParameterKey': 'someParameterValue']
+            def plugin = new ConfirmApplyPlugin()
+            ConfirmApplyPlugin.withParameter(expectedParameter)
+
+            def parameters = plugin.getInputOptions()['parameters']
+
+            assertThat(parameters, contains(expectedParameter))
+        }
     }
 }
 

--- a/test/ConfirmApplyPluginTest.groovy
+++ b/test/ConfirmApplyPluginTest.groovy
@@ -44,6 +44,26 @@ class ConfirmApplyPluginTest {
 
     class GetInputOptions {
         @Test
+        void defaultsToASubmitterParameterOfApprover() {
+            def plugin = new ConfirmApplyPlugin()
+
+            def actual = plugin.getInputOptions('env')['submitterParameter']
+
+            assertEquals(ConfirmApplyPlugin.DEFAULT_SUBMITTER_PARAMETER, actual)
+        }
+
+        @Test
+        void usesTheGivenSubmitterParameter() {
+            def expected = 'submitterOverride'
+            def plugin = new ConfirmApplyPlugin()
+            ConfirmApplyPlugin.withSubmitterParameter(expected)
+
+            def actual = plugin.getInputOptions('env')['submitterParameter']
+
+            assertEquals(expected, actual)
+        }
+
+        @Test
         void defaultsToNoExtraParameters() {
             def plugin = new ConfirmApplyPlugin()
 
@@ -139,6 +159,42 @@ class ConfirmApplyPluginTest {
             plugin.checkConfirmConditions(expectedUserInput, 'someEnv')
 
             assertEquals(expectedUserInput, actualUserInput)
+        }
+    }
+
+    class WithParameter {
+        @Test
+        void isFluent() {
+            def result = ConfirmApplyPlugin.withParameter([:])
+
+            assertEquals(ConfirmApplyPlugin.class, result)
+        }
+    }
+
+    class WithConfirmMessage {
+        @Test
+        void isFluent() {
+            def result = ConfirmApplyPlugin.withConfirmMessage('someMessage')
+
+            assertEquals(ConfirmApplyPlugin.class, result)
+        }
+    }
+
+    class WithOkMessage {
+        @Test
+        void isFluent() {
+            def result = ConfirmApplyPlugin.withOkMessage('someMessage')
+
+            assertEquals(ConfirmApplyPlugin.class, result)
+        }
+    }
+
+    class WithSubmitterParameter {
+        @Test
+        void isFluent() {
+            def result = ConfirmApplyPlugin.withSubmitterParameter('someParam')
+
+            assertEquals(ConfirmApplyPlugin.class, result)
         }
     }
 }

--- a/test/DestroyPluginTest.groovy
+++ b/test/DestroyPluginTest.groovy
@@ -2,9 +2,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.mock
 
 import org.junit.Test
 import org.junit.Before
@@ -14,19 +14,21 @@ import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class DestroyPluginTest {
-
     @Before
-    void resetJenkinsEnv() {
-        Jenkinsfile.instance = mock(Jenkinsfile.class)
-        when(Jenkinsfile.instance.getEnv()).thenReturn([:])
+    @After
+    void reset() {
+        Jenkinsfile.reset()
+        ConfirmApplyPlugin.reset()
+        TerraformEnvironmentStage.reset()
+        TerraformPlanCommand.resetPlugins()
+        TerraformApplyCommand.resetPlugins()
     }
 
     public class Init {
-        @After
-        void resetPlugins() {
-            TerraformEnvironmentStage.reset()
-            TerraformPlanCommand.resetPlugins()
-            TerraformApplyCommand.resetPlugins()
+        @Before
+        void setup() {
+            Jenkinsfile.instance = mock(Jenkinsfile.class)
+            doReturn('repoName').when(Jenkinsfile.instance).getRepoName()
         }
 
         @Test

--- a/test/DestroyPluginTest.groovy
+++ b/test/DestroyPluginTest.groovy
@@ -1,8 +1,10 @@
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
 
@@ -137,6 +139,22 @@ class DestroyPluginTest {
             def result = DestroyPlugin.withArgument('-arg1')
 
             assertEquals(DestroyPlugin.class, result)
+        }
+    }
+
+    class ConfirmCondition {
+        @Test
+        void returnsTrueIfConfirmationInputDoesNotMatch() {
+            def condition = DestroyPlugin.getConfirmCondition('myApp')
+
+            assertTrue(condition.call(['environment': 'foo', 'input': ['CONFIRM_DESTROY': 'destroy myApp foo']]))
+        }
+
+        @Test
+        void returnsFalseIfConfirmationInputDoesNotMatch() {
+            def condition = DestroyPlugin.getConfirmCondition('myApp')
+
+            assertFalse(condition.call(['environment': 'foo', 'input': ['CONFIRM_DESTROY': 'anythingElse']]))
         }
     }
 }


### PR DESCRIPTION
* This closes #261, and builds on the original Issue #88 
* Require the user to type in  something to confirm that they want to destroy, it make it more difficult to make a mistake