### PR TITLE
Issue 289: TagPlugin should work with both v11 and v12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #289](https://github.com/manheim/terraform-pipeline/issues/289) TagPlugin should work with both terraform 0.11.x and 0.12.x
 * [Issue #254](https://github.com/manheim/terraform-pipeline/issues/254) Auto-convert git/ssh-urls to https with GithubPRPlanPlugin
 
 # v5.9

--- a/src/TagPlugin.groovy
+++ b/src/TagPlugin.groovy
@@ -22,10 +22,10 @@ class TagPlugin implements TerraformPlanCommandPlugin,
     }
 
     private void applyToCommand(command) {
-        def variableName = getVariableName()
-        def tagString = getTagsAsString(command)
+        String variableName = getVariableName()
+        Map tags = getTags(command)
 
-        command.withVariable(variableName, tagString)
+        command.withVariable(variableName, tags)
     }
 
     public static withVariableName(String variableName) {
@@ -33,22 +33,38 @@ class TagPlugin implements TerraformPlanCommandPlugin,
     }
 
     public static withEnvironmentTag(String tagKey = 'environment') {
-        tagClosures << { command -> "\"${tagKey}\":\"${command.getEnvironment()}\"" }
+        tagClosures << { command ->
+            Map tag = [:]
+            tag[tagKey] = command.getEnvironment()
+            tag
+        }
         return this
     }
 
     public static withTag(String key, String value) {
-        tagClosures << { command -> "\"${key}\":\"${value}\"" }
+        tagClosures << { command ->
+            Map tag = [:]
+            tag[key] = value
+            tag
+        }
         return this
     }
 
     public static withTagFromFile(String key, String filename) {
-        tagClosures << { command -> "\"${key}\":\"${Jenkinsfile.readFile(filename)}\"" }
+        tagClosures << { command ->
+            Map tag = [:]
+            tag[key] = Jenkinsfile.readFile(filename)
+            tag
+        }
         return this
     }
 
     public static withTagFromEnvironmentVariable(String key, String variable) {
-        tagClosures << { command -> "\"${key}\":\"${Jenkinsfile.getEnvironmentVariable(variable)}\"" }
+        tagClosures << { command ->
+            Map tag = [:]
+            tag[key] = Jenkinsfile.getEnvironmentVariable(variable)
+            tag
+        }
         return this
     }
 
@@ -56,9 +72,10 @@ class TagPlugin implements TerraformPlanCommandPlugin,
         return variableName ?: 'tags'
     }
 
-    public String getTagsAsString(TerraformCommand command) {
-        def result = tagClosures.collect { it.call(command) }.join(',')
-        return "{${result}}"
+    public Map getTags(TerraformCommand command) {
+        return tagClosures.inject([:]) { memo, tagClosure ->
+            memo + tagClosure.call(command)
+        }
     }
 
     public static reset() {

--- a/src/TagPlugin.groovy
+++ b/src/TagPlugin.groovy
@@ -22,11 +22,10 @@ class TagPlugin implements TerraformPlanCommandPlugin,
     }
 
     private void applyToCommand(command) {
-        def tagString = getTagsAsString(command)
         def variableName = getVariableName()
-        def tagArgument = "-var=\'${variableName}=${tagString}\'"
+        def tagString = getTagsAsString(command)
 
-        command.withArgument(tagArgument)
+        command.withVariable(variableName, tagString)
     }
 
     public static withVariableName(String variableName) {

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -30,6 +30,10 @@ class TerraformApplyCommand implements TerraformCommand {
         return this
     }
 
+    public TerraformApplyCommand withVariable(String key, Map value) {
+        return withVariable(key, convertMapToCliString(value))
+    }
+
     public TerraformApplyCommand withVariable(String key, String value) {
         def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
         this.args << pattern.call(key, value).toString()
@@ -39,6 +43,10 @@ class TerraformApplyCommand implements TerraformCommand {
     public TerraformApplyCommand withVariablePattern(Closure pattern) {
         this.variablePattern = pattern
         return this
+    }
+
+    public String convertMapToCliString(Map value) {
+        return value.toString()
     }
 
     public TerraformApplyCommand withPrefix(String prefix) {

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -9,6 +9,7 @@ class TerraformApplyCommand implements TerraformCommand {
     private static plugins = []
     private appliedPlugins = []
     private String directory
+    private Closure variablePattern
 
     public TerraformApplyCommand(String environment) {
         this.environment = environment
@@ -26,6 +27,17 @@ class TerraformApplyCommand implements TerraformCommand {
 
     public TerraformApplyCommand withArgument(String arg) {
         this.args << arg
+        return this
+    }
+
+    public TerraformApplyCommand withVariable(String key, String value) {
+        def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
+        this.args << pattern.call(key, value).toString()
+        return this
+    }
+
+    public TerraformApplyCommand withVariablePattern(Closure pattern) {
+        this.variablePattern = pattern
         return this
     }
 

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -10,6 +10,7 @@ class TerraformApplyCommand implements TerraformCommand {
     private appliedPlugins = []
     private String directory
     private Closure variablePattern
+    private Closure mapPattern
 
     public TerraformApplyCommand(String environment) {
         this.environment = environment
@@ -45,8 +46,18 @@ class TerraformApplyCommand implements TerraformCommand {
         return this
     }
 
-    public String convertMapToCliString(Map value) {
-        return value.toString()
+    public String convertMapToCliString(Map newMap) {
+        def pattern = mapPattern ?: { map ->
+            def result = map.collect { key, value -> "${key}=\"${value}\"" }.join(',')
+            return "{${result}}"
+        }
+
+        return pattern.call(newMap)
+    }
+
+    public TerraformApplyCommand withMapPattern(Closure pattern) {
+        this.mapPattern = pattern
+        return this
     }
 
     public TerraformApplyCommand withPrefix(String prefix) {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -11,6 +11,7 @@ class TerraformPlanCommand implements TerraformCommand {
     private appliedPlugins = []
     private String directory
     private String errorFile
+    private Closure variablePattern
 
     public TerraformPlanCommand(String environment) {
         this.environment = environment
@@ -42,7 +43,13 @@ class TerraformPlanCommand implements TerraformCommand {
     }
 
     public TerraformPlanCommand withVariable(String key, String value) {
-        this.arguments << "-var '${key}=${value}'"
+        def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
+        this.arguments << pattern.call(key, value).toString()
+        return this
+    }
+
+    public TerraformPlanCommand withVariablePattern(Closure pattern) {
+        this.variablePattern = pattern
         return this
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -12,6 +12,7 @@ class TerraformPlanCommand implements TerraformCommand {
     private String directory
     private String errorFile
     private Closure variablePattern
+    private Closure mapPattern
 
     public TerraformPlanCommand(String environment) {
         this.environment = environment
@@ -57,8 +58,18 @@ class TerraformPlanCommand implements TerraformCommand {
         return this
     }
 
-    public String convertMapToCliString(Map value) {
-        return value.toString()
+    public String convertMapToCliString(Map newMap) {
+        def pattern = mapPattern ?: { map ->
+            def result = map.collect { key, value -> "${key}=\"${value}\"" }.join(',')
+            return "{${result}}"
+        }
+
+        return pattern.call(newMap)
+    }
+
+    public TerraformPlanCommand withMapPattern(Closure pattern) {
+        this.mapPattern = pattern
+        return this
     }
 
     public TerraformPlanCommand withStandardErrorRedirection(String errorFile) {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -41,6 +41,11 @@ class TerraformPlanCommand implements TerraformCommand {
         return this
     }
 
+    public TerraformPlanCommand withVariable(String key, String value) {
+        this.arguments << "-var '${key}=${value}'"
+        return this
+    }
+
     public TerraformPlanCommand withStandardErrorRedirection(String errorFile) {
         this.errorFile = errorFile
         return this

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -42,6 +42,10 @@ class TerraformPlanCommand implements TerraformCommand {
         return this
     }
 
+    public TerraformPlanCommand withVariable(String key, Map value) {
+        return withVariable(key, convertMapToCliString(value))
+    }
+
     public TerraformPlanCommand withVariable(String key, String value) {
         def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
         this.arguments << pattern.call(key, value).toString()
@@ -51,6 +55,10 @@ class TerraformPlanCommand implements TerraformCommand {
     public TerraformPlanCommand withVariablePattern(Closure pattern) {
         this.variablePattern = pattern
         return this
+    }
+
+    public String convertMapToCliString(Map value) {
+        return value.toString()
     }
 
     public TerraformPlanCommand withStandardErrorRedirection(String errorFile) {

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -73,7 +73,7 @@ class TerraformPlugin implements TerraformValidateCommandPlugin,
         this.version = userVersion
     }
 
-    static  void resetVersion() {
+    static  void reset() {
         this.version = null
     }
 

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -9,7 +9,10 @@
  * See TerraformPluginVersion11 or TerraformPluginVersion12 for an example
  * before strating on your own.
  */
-class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValidateStagePlugin {
+class TerraformPlugin implements TerraformValidateCommandPlugin,
+                                 TerraformPlanCommandPlugin,
+                                 TerraformApplyCommandPlugin,
+                                 TerraformValidateStagePlugin {
 
     static String version
     static final String DEFAULT_VERSION = '0.11.0'
@@ -19,6 +22,8 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
         def plugin = new TerraformPlugin()
 
         TerraformValidateCommand.addPlugin(plugin)
+        TerraformPlanCommand.addPlugin(plugin)
+        TerraformApplyCommand.addPlugin(plugin)
         TerraformValidateStage.addPlugin(plugin)
     }
 
@@ -87,6 +92,20 @@ class TerraformPlugin implements TerraformValidateCommandPlugin, TerraformValida
 
     @Override
     void apply(TerraformValidateCommand command) {
+        applyToCommand(command)
+    }
+
+    @Override
+    void apply(TerraformPlanCommand command) {
+        applyToCommand(command)
+    }
+
+    @Override
+    void apply(TerraformApplyCommand command) {
+        applyToCommand(command)
+    }
+
+    void applyToCommand(command) {
         def version = detectVersion()
 
         def strategy = strategyFor(version)

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -75,6 +75,11 @@ class TerraformPlugin implements TerraformValidateCommandPlugin,
 
     static  void reset() {
         this.version = null
+
+        TerraformValidateCommand.resetPlugins()
+        TerraformPlanCommand.resetPlugins()
+        TerraformApplyCommand.resetPlugins()
+        TerraformValidateStage.resetPlugins()
     }
 
     public boolean fileExists(String filename) {

--- a/src/TerraformPluginVersion.groovy
+++ b/src/TerraformPluginVersion.groovy
@@ -1,4 +1,7 @@
-abstract class TerraformPluginVersion implements TerraformValidateStagePlugin, TerraformValidateCommandPlugin {
+abstract class TerraformPluginVersion implements TerraformValidateStagePlugin,
+                                                 TerraformValidateCommandPlugin,
+                                                 TerraformPlanCommandPlugin,
+                                                 TerraformApplyCommandPlugin {
     @Override
     public void apply(TerraformValidateStage validateStage) {
     }
@@ -7,4 +10,11 @@ abstract class TerraformPluginVersion implements TerraformValidateStagePlugin, T
     public void apply(TerraformValidateCommand command) {
     }
 
+    @Override
+    public void apply(TerraformPlanCommand command) {
+    }
+
+    @Override
+    public void apply(TerraformApplyCommand command) {
+    }
 }

--- a/src/TerraformPluginVersion12.groovy
+++ b/src/TerraformPluginVersion12.groovy
@@ -20,9 +20,17 @@ class TerraformPluginVersion12 extends TerraformPluginVersion {
 
     public void apply(TerraformPlanCommand command) {
         command.withVariablePattern { key, value -> "-var='${key}=${value}'" }
+               .withMapPattern { map ->
+                def result = map.collect { key, value -> "\"${key}\":\"${value}\"" }.join(',')
+                return "{${result}}"
+               }
     }
 
     public void apply(TerraformApplyCommand command) {
         command.withVariablePattern { key, value -> "-var='${key}=${value}'" }
+               .withMapPattern { map ->
+                def result = map.collect { key, value -> "\"${key}\":\"${value}\"" }.join(',')
+                return "{${result}}"
+               }
     }
 }

--- a/src/TerraformPluginVersion12.groovy
+++ b/src/TerraformPluginVersion12.groovy
@@ -17,4 +17,12 @@ class TerraformPluginVersion12 extends TerraformPluginVersion {
     public static TerraformInitCommand initCommandForValidate() {
         return TerraformInitCommand.instanceFor('validate').withoutBackend()
     }
+
+    public void apply(TerraformPlanCommand command) {
+        command.withVariablePattern { key, value -> "-var='${key}=${value}'" }
+    }
+
+    public void apply(TerraformApplyCommand command) {
+        command.withVariablePattern { key, value -> "-var='${key}=${value}'" }
+    }
 }

--- a/test/DummyJenkinsfile.groovy
+++ b/test/DummyJenkinsfile.groovy
@@ -31,6 +31,10 @@ class DummyJenkinsfile {
         println "DummyJenkinsfile.node(${nodeName})"
         closure()
     }
+    public node(Closure closure) {
+        println "DummyJenkinsfile.node { }"
+        closure()
+    }
     public deleteDir() { println "DummyJenkinsfile.deleteDir" }
     public checkout(scm) { println "DummyJenkinsfile.checkout(${scm})" }
     public withEnv(Collection env, Closure closure) {
@@ -47,5 +51,10 @@ class DummyJenkinsfile {
     }
     public input(options) {
         println "DummyJenkinsfile.input(${options})"
+    }
+    public ApplyJenkinsfileClosure(Closure closure) {
+        println "DummyJenkinsfile.ApplyJenkinsfileClosure"
+        closure.delegate = this
+        closure()
     }
 }

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -81,10 +81,10 @@ class TagPluginTest {
         @Test
         public void addsTheTagArgument() {
             def expectedVariableName = 'tags'
-            def expectedTags = '{"key1":"value1","key2":"value2"}'
+            def expectedTags = [key1:'value1', key2: 'value2']
             def command = spy(new TerraformPlanCommand())
             def plugin = spy(new TagPlugin())
-            doReturn(expectedTags).when(plugin).getTagsAsString(command)
+            doReturn(expectedTags).when(plugin).getTags(command)
 
             plugin.apply(command)
 
@@ -98,8 +98,8 @@ class TagPluginTest {
                 TagPlugin.withVariableName(expectedVariableName)
                 def command = spy(new TerraformPlanCommand())
                 def plugin = spy(new TagPlugin())
-                def expectedTags = '{"key1":"value1","key2":"value2"}'
-                doReturn(expectedTags).when(plugin).getTagsAsString(command)
+                def expectedTags = [key1: 'value1', key2: 'value2']
+                doReturn(expectedTags).when(plugin).getTags(command)
 
                 plugin.apply(command)
 
@@ -112,10 +112,10 @@ class TagPluginTest {
         @Test
         public void addsTheTagArgument() {
             def expectedVariableName = 'tags'
-            def expectedTags = '{"key1":"value1","key2":"value2"}'
+            def expectedTags = [key1:'value1', key2:'value2']
             def command = spy(new TerraformApplyCommand())
             def plugin = spy(new TagPlugin())
-            doReturn(expectedTags).when(plugin).getTagsAsString(command)
+            doReturn(expectedTags).when(plugin).getTags(command)
 
             plugin.apply(command)
 
@@ -126,11 +126,11 @@ class TagPluginTest {
             @Test
             void overridesTheDefaultVariableName() {
                 def expectedVariableName = 'myVar'
-                def expectedTags = '{"key1":"value1","key2":"value2"}'
+                def expectedTags = [key1:'value1', key2:'value2']
                 TagPlugin.withVariableName(expectedVariableName)
                 def command = spy(new TerraformApplyCommand())
                 def plugin = spy(new TagPlugin())
-                doReturn(expectedTags).when(plugin).getTagsAsString(command)
+                doReturn(expectedTags).when(plugin).getTags(command)
 
                 plugin.apply(command)
 
@@ -139,24 +139,24 @@ class TagPluginTest {
         }
     }
 
-    public class GetTagsAsString {
+    public class GetTags {
         @Test
-        void returnsAndEmptyMapStringIfNoKeyValuePairsWereAdded() {
+        void returnsAndEmptyMapIfNoKeyValuePairsWereAdded() {
             def plugin = new TagPlugin()
 
-            def result = plugin.getTagsAsString()
+            def result = plugin.getTags()
 
-            assertEquals("{}", result)
+            assertEquals([:], result)
         }
 
         @Test
         void constructMapStringUsingASingleKeyValuePair() {
             def plugin = new TagPlugin()
-            plugin.withTag('key', 'value')
+            plugin.withTag('mykey', 'myvalue')
 
-            def result = plugin.getTagsAsString()
+            def result = plugin.getTags()
 
-            assertEquals('{"key":"value"}', result)
+            assertEquals([mykey: 'myvalue'], result)
         }
 
         @Test
@@ -165,9 +165,9 @@ class TagPluginTest {
             plugin.withTag('key1', 'value1')
             plugin.withTag('key2', 'value2')
 
-            def result = plugin.getTagsAsString()
+            def result = plugin.getTags()
 
-            assertEquals('{"key1":"value1","key2":"value2"}', result)
+            assertEquals([key1: 'value1', key2: 'value2'], result)
         }
 
         @Test
@@ -177,9 +177,9 @@ class TagPluginTest {
             def command = mock(TerraformCommand.class)
             doReturn('myenv').when(command).getEnvironment()
 
-            def result = plugin.getTagsAsString(command)
+            def result = plugin.getTags(command)
 
-            assertEquals('{"environment":"myenv"}', result)
+            assertEquals([ environment: 'myenv' ], result)
         }
 
         @Test
@@ -190,9 +190,11 @@ class TagPluginTest {
             def command = mock(TerraformCommand.class)
             doReturn('myenv').when(command).getEnvironment()
 
-            def result = plugin.getTagsAsString(command)
+            def result = plugin.getTags(command)
 
-            assertEquals("{\"${expectedTagKey}\":\"myenv\"}".toString(), result)
+            Map expectedResult = [:]
+            expectedResult[expectedTagKey] = 'myenv'
+            assertEquals(expectedResult, result)
         }
 
         @Test
@@ -208,18 +210,17 @@ class TagPluginTest {
             doReturn(fileContent).when(original).readFile(file)
             Jenkinsfile.original = original
 
-            def result = plugin.getTagsAsString(command)
+            def result = plugin.getTags(command)
 
-            assertEquals("{\"${key}\":\"${fileContent}\"}".toString(), result)
+            assertEquals(['change-id': "${fileContent}".toString()], result)
         }
 
         @Test
         void constructsTagsFromEnvironmentVariables() {
-            def key = 'someTagName'
             def variable = 'MY_ENV'
             def expectedValue = 'valueOfMY_ENV'
             def plugin = new TagPlugin()
-            plugin.withTagFromEnvironmentVariable(key, variable)
+            plugin.withTagFromEnvironmentVariable('someTagName', variable)
             def command = mock(TerraformCommand.class)
             def original = new DummyJenkinsfile()
             original.env = [:]
@@ -227,9 +228,9 @@ class TagPluginTest {
 
             Jenkinsfile.original = original
 
-            def result = plugin.getTagsAsString(command)
+            def result = plugin.getTags(command)
 
-            assertEquals("{\"${key}\":\"${expectedValue}\"}".toString(), result)
+            assertEquals([ 'someTagName': expectedValue ], result)
         }
 
         @Test
@@ -241,9 +242,9 @@ class TagPluginTest {
             def command = mock(TerraformCommand.class)
             doReturn('myenv').when(command).getEnvironment()
 
-            def result = plugin.getTagsAsString(command)
+            def result = plugin.getTags(command)
 
-            assertEquals('{"key1":"value1","environment":"myenv","key2":"value2"}', result)
+            assertEquals([key1: 'value1', environment: 'myenv', key2: 'value2'], result)
         }
     }
 }

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -1,4 +1,3 @@
-import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.junit.Assert.assertThat
@@ -6,6 +5,7 @@ import static org.junit.Assert.assertEquals
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test
 import org.junit.Before
@@ -80,15 +80,15 @@ class TagPluginTest {
     public class ApplyForPlanCommand {
         @Test
         public void addsTheTagArgument() {
+            def expectedVariableName = 'tags'
             def expectedTags = '{"key1":"value1","key2":"value2"}'
-            def command = new TerraformPlanCommand()
+            def command = spy(new TerraformPlanCommand())
             def plugin = spy(new TagPlugin())
             doReturn(expectedTags).when(plugin).getTagsAsString(command)
 
             plugin.apply(command)
-            def result = command.toString()
 
-            assertThat(result, containsString("-var=\'tags=${expectedTags}\'"))
+            verify(command).withVariable(expectedVariableName, expectedTags)
         }
 
         class WithVariableName {
@@ -96,13 +96,14 @@ class TagPluginTest {
             void overridesTheDefaultVariableName() {
                 def expectedVariableName = 'myVar'
                 TagPlugin.withVariableName(expectedVariableName)
-                def command = new TerraformPlanCommand()
-                def plugin = new TagPlugin()
+                def command = spy(new TerraformPlanCommand())
+                def plugin = spy(new TagPlugin())
+                def expectedTags = '{"key1":"value1","key2":"value2"}'
+                doReturn(expectedTags).when(plugin).getTagsAsString(command)
 
                 plugin.apply(command)
-                def result = command.toString()
 
-                assertThat(result, containsString("-var=\'${expectedVariableName}={}'"))
+                verify(command).withVariable(expectedVariableName, expectedTags)
             }
         }
     }
@@ -110,32 +111,32 @@ class TagPluginTest {
     public class ApplyForApplyCommand {
         @Test
         public void addsTheTagArgument() {
+            def expectedVariableName = 'tags'
             def expectedTags = '{"key1":"value1","key2":"value2"}'
-            def command = new TerraformApplyCommand()
+            def command = spy(new TerraformApplyCommand())
             def plugin = spy(new TagPlugin())
             doReturn(expectedTags).when(plugin).getTagsAsString(command)
 
             plugin.apply(command)
-            def result = command.toString()
 
-            assertThat(result, containsString("-var=\'tags=${expectedTags}\'"))
+            verify(command).withVariable(expectedVariableName, expectedTags)
         }
 
         class WithVariableName {
             @Test
             void overridesTheDefaultVariableName() {
                 def expectedVariableName = 'myVar'
+                def expectedTags = '{"key1":"value1","key2":"value2"}'
                 TagPlugin.withVariableName(expectedVariableName)
-                def command = new TerraformApplyCommand()
-                def plugin = new TagPlugin()
+                def command = spy(new TerraformApplyCommand())
+                def plugin = spy(new TagPlugin())
+                doReturn(expectedTags).when(plugin).getTagsAsString(command)
 
                 plugin.apply(command)
-                def result = command.toString()
 
-                assertThat(result, containsString("-var=\'${expectedVariableName}={}'"))
+                verify(command).withVariable(expectedVariableName, expectedTags)
             }
         }
-
     }
 
     public class GetTagsAsString {

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -2,8 +2,11 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.endsWith
 import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.startsWith
+import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
@@ -59,7 +62,7 @@ class TerraformApplyCommandTest {
         }
     }
 
-    public class WithVariable {
+    public class WithVariableString {
         @Test
         void addsArgument() {
             def expectedKey = 'myKey'
@@ -89,6 +92,52 @@ class TerraformApplyCommandTest {
                 def actualCommand = command.toString()
                 assertThat(actualCommand, containsString("boop-foo-bar-boop"))
             }
+        }
+    }
+
+    public class WithVariableMap {
+        @Test
+        void convertsMapToStringAndTreatsLikeAStringVariable() {
+            def expectedKey = 'myKey'
+            def expectedMap = [mapKey: 'mapValue']
+            def command = spy(new TerraformApplyCommand())
+            doReturn('someMapString').when(command).convertMapToCliString(expectedMap)
+
+            command.withVariable(expectedKey, expectedMap)
+
+            verify(command).withVariable(expectedKey, 'someMapString')
+        }
+    }
+
+    public class ConvertMapToCliString {
+        @Test
+        void handlesSingleKeyPair() {
+            def map = [mapKey: 'mapValue']
+            def command = new TerraformApplyCommand()
+
+            def result = command.convertMapToCliString(map)
+            assertEquals('{mapKey=\"mapValue\"}', result)
+        }
+
+        @Test
+        void handlesMultipleKeyPairs() {
+            def map = [mapKey1: 'mapValue1', mapKey2: 'mapValue2']
+            def command = new TerraformApplyCommand()
+
+            def result = command.convertMapToCliString(map)
+            assertEquals('{mapKey1=\"mapValue1\",mapKey2=\"mapValue2\"}', result)
+        }
+
+        @Test
+        void usesMapPatternIfGiven() {
+            def command = new TerraformApplyCommand().withMapPattern { map ->
+                def result = map.collect { key, value -> "${value}|${key}" }.join(';')
+                return "[${result}]"
+            }
+            def map = [mapKey1: 'mapValue1', mapKey2: 'mapValue2']
+
+            def result = command.convertMapToCliString(map)
+            assertEquals('[mapValue1|mapKey1;mapValue2|mapKey2]', result)
         }
     }
 

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -59,6 +59,39 @@ class TerraformApplyCommandTest {
         }
     }
 
+    public class WithVariable {
+        @Test
+        void addsArgument() {
+            def expectedKey = 'myKey'
+            def expectedValue = 'myValue'
+            def command = new TerraformApplyCommand().withVariable(expectedKey, expectedValue)
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString("-var '${expectedKey}=${expectedValue}'"))
+        }
+
+        @Test
+        void isCumulative() {
+            def command = new TerraformApplyCommand().withVariable('key1', 'val1')
+                                                    .withVariable('key2', 'val2')
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString("-var 'key1=val1'"))
+            assertThat(actualCommand, containsString("-var 'key2=val2'"))
+        }
+
+        class WithVariablePattern {
+            @Test
+            void usesTheNewPattern() {
+                def command = new TerraformApplyCommand().withVariablePattern { key, value -> "boop-${key}-${value}-boop" }
+                                                         .withVariable('foo', 'bar')
+
+                def actualCommand = command.toString()
+                assertThat(actualCommand, containsString("boop-foo-bar-boop"))
+            }
+        }
+    }
+
     public class WithDirectory {
         @Test
         void addsDirectoryArgument() {
@@ -109,8 +142,8 @@ class TerraformApplyCommandTest {
 
         @Test
         void isCumulative() {
-            def command = new TerraformPlanCommand().withSuffix("fooSuffix")
-                                                    .withSuffix("> /dev/null")
+            def command = new TerraformApplyCommand().withSuffix("fooSuffix")
+                                                     .withSuffix("> /dev/null")
 
             def actualCommand = command.toString()
             assertThat(actualCommand, endsWith("fooSuffix > /dev/null"))

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -118,6 +118,28 @@ class TerraformPlanCommandTest {
         }
     }
 
+    public class WithVariable {
+        @Test
+        void addsArgument() {
+            def expectedKey = 'myKey'
+            def expectedValue = 'myValue'
+            def command = new TerraformPlanCommand().withVariable(expectedKey, expectedValue)
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString("-var '${expectedKey}=${expectedValue}'"))
+        }
+
+        @Test
+        void isCumulative() {
+            def command = new TerraformPlanCommand().withVariable('key1', 'val1')
+                                                    .withVariable('key2', 'val2')
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString("-var 'key1=val1'"))
+            assertThat(actualCommand, containsString("-var 'key2=val2'"))
+        }
+    }
+
     public class WithStandardErrorRedirection {
         @Test
         void sendsStandardErrorToTheGivenFile() {

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -138,6 +138,17 @@ class TerraformPlanCommandTest {
             assertThat(actualCommand, containsString("-var 'key1=val1'"))
             assertThat(actualCommand, containsString("-var 'key2=val2'"))
         }
+
+        class WithVariablePattern {
+            @Test
+            void usesTheNewPattern() {
+                def command = new TerraformPlanCommand().withVariablePattern { key, value -> "boop-${key}-${value}-boop" }
+                                                        .withVariable('foo', 'bar')
+
+                def actualCommand = command.toString()
+                assertThat(actualCommand, containsString("boop-foo-bar-boop"))
+            }
+        }
     }
 
     public class WithStandardErrorRedirection {

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -179,6 +179,36 @@ class TerraformPluginTest {
         }
     }
 
+    class ApplyTerraformPlanCommand {
+        @Test
+        void shouldApplyTheCorrectStrategyToTerraformPlanCommand() {
+            def planCommand = mock(TerraformPlanCommand.class)
+            def strategy = mock(TerraformPluginVersion.class)
+            def plugin = spy(new TerraformPlugin())
+            doReturn('someVersion').when(plugin).detectVersion()
+            doReturn(strategy).when(plugin).strategyFor('someVersion')
+
+            plugin.apply(planCommand)
+
+            verify(strategy, times(1)).apply(planCommand)
+        }
+    }
+
+    class ApplyTerraformApplyCommand {
+        @Test
+        void shouldApplyTheCorrectStrategyToTerraformApplyCommand() {
+            def applyCommand = mock(TerraformApplyCommand.class)
+            def strategy = mock(TerraformPluginVersion.class)
+            def plugin = spy(new TerraformPlugin())
+            doReturn('someVersion').when(plugin).detectVersion()
+            doReturn(strategy).when(plugin).strategyFor('someVersion')
+
+            plugin.apply(applyCommand)
+
+            verify(strategy, times(1)).apply(applyCommand)
+        }
+    }
+
     class ApplyTerraformValidateStage {
         @Test
         void shouldDecorateTheGivenStage() {

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -24,6 +24,17 @@ class TerraformPluginTest {
         }
 
         @Test
+        void usesExplicitVersionIfProvided() {
+            def expectedVersion = 'foo'
+            def plugin = new TerraformPlugin()
+            TerraformPlugin.withVersion(expectedVersion)
+
+            def foundVersion = plugin.detectVersion()
+
+            assertEquals(expectedVersion, foundVersion)
+        }
+
+        @Test
         void usesDefaultIfNoFilePresent() {
             def plugin = spy(new TerraformPlugin())
             doReturn(false).when(plugin).fileExists(TerraformPlugin.TERRAFORM_VERSION_FILE)

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
@@ -54,6 +55,22 @@ class TerraformPluginTest {
             def foundVersion = plugin.detectVersion()
 
             assertEquals(expectedVersion, foundVersion)
+        }
+    }
+
+    class CheckVersion {
+        @Before
+        @After
+        void reset() {
+            TerraformPlugin.reset()
+            Jenkinsfile.reset()
+        }
+
+        // This can be fleshed out.  For now, jusst make sure it runs
+        @Test
+        void doesNotError() {
+            Jenkinsfile.original = new DummyJenkinsfile()
+            TerraformPlugin.checkVersion()
         }
     }
 

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -19,8 +19,8 @@ class TerraformPluginTest {
 
     class VersionDetection {
         @After
-        void resetVersion() {
-            TerraformPlugin.resetVersion()
+        void reset() {
+            TerraformPlugin.reset()
         }
 
         @Test
@@ -48,8 +48,8 @@ class TerraformPluginTest {
 
     class WithVersion {
         @After
-        void resetVersion() {
-            TerraformPlugin.resetVersion()
+        void reset() {
+            TerraformPlugin.reset()
         }
 
         @Test
@@ -61,8 +61,8 @@ class TerraformPluginTest {
 
     class Strategyfor {
         @After
-        void resetVersion() {
-            TerraformPlugin.resetVersion()
+        void reset() {
+            TerraformPlugin.reset()
         }
 
         @Test

--- a/test/TerraformPluginVersion11Test.groovy
+++ b/test/TerraformPluginVersion11Test.groovy
@@ -1,3 +1,5 @@
+import static org.hamcrest.Matchers.containsString
+import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify;
 
@@ -17,6 +19,34 @@ class TerraformPluginVersion11Test {
             version11.apply((TerraformValidateCommand)validateCommand)
 
             verify(validateCommand).withArgument('-check-variables=false')
+        }
+    }
+
+    class ModifiesTerraformPlanCommand {
+        @Test
+        void toPreserveTerraform11CliSyntaxForVariables() {
+            def plan = new TerraformPlanCommand()
+            def version12 = new TerraformPluginVersion11()
+
+            version12.apply(plan)
+            plan.withVariable('key', 'value')
+            def result = plan.toString()
+
+            assertThat(result, containsString("-var 'key=value'"))
+        }
+    }
+
+    class ModifiesTerraformApplyCommand {
+        @Test
+        void toPreserveTerraform11CliSyntaxForVariables() {
+            def applyCommand = new TerraformApplyCommand()
+            def version12 = new TerraformPluginVersion11()
+
+            version12.apply(applyCommand)
+            applyCommand.withVariable('key', 'value')
+            def result = applyCommand.toString()
+
+            assertThat(result, containsString("-var 'key=value'"))
         }
     }
 }

--- a/test/TerraformPluginVersion11Test.groovy
+++ b/test/TerraformPluginVersion11Test.groovy
@@ -26,6 +26,7 @@ class TerraformPluginVersion11Test {
         @Test
         void toPreserveTerraform11CliSyntaxForVariables() {
             def plan = new TerraformPlanCommand()
+            println "plugins for plan: ${plan.getPlugins()}"
             def version11 = new TerraformPluginVersion11()
 
             version11.apply(plan)

--- a/test/TerraformPluginVersion11Test.groovy
+++ b/test/TerraformPluginVersion11Test.groovy
@@ -3,12 +3,19 @@ import static org.junit.Assert.assertThat
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify;
 
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
 
 @RunWith(HierarchicalContextRunner.class)
 class TerraformPluginVersion11Test {
+    @Before
+    @After
+    void reset() {
+        TerraformPlugin.reset()
+    }
 
     class ModifiesTerraformValidateCommand {
         @Test

--- a/test/TerraformPluginVersion11Test.groovy
+++ b/test/TerraformPluginVersion11Test.groovy
@@ -33,7 +33,6 @@ class TerraformPluginVersion11Test {
         @Test
         void toPreserveTerraform11CliSyntaxForVariables() {
             def plan = new TerraformPlanCommand()
-            println "plugins for plan: ${plan.getPlugins()}"
             def version11 = new TerraformPluginVersion11()
 
             version11.apply(plan)

--- a/test/TerraformPluginVersion11Test.groovy
+++ b/test/TerraformPluginVersion11Test.groovy
@@ -26,13 +26,25 @@ class TerraformPluginVersion11Test {
         @Test
         void toPreserveTerraform11CliSyntaxForVariables() {
             def plan = new TerraformPlanCommand()
-            def version12 = new TerraformPluginVersion11()
+            def version11 = new TerraformPluginVersion11()
 
-            version12.apply(plan)
+            version11.apply(plan)
             plan.withVariable('key', 'value')
             def result = plan.toString()
 
             assertThat(result, containsString("-var 'key=value'"))
+        }
+
+        @Test
+        void toPreserveTerraform11CliFormatForMapVariables() {
+            def plan = new TerraformPlanCommand()
+            def version11 = new TerraformPluginVersion11()
+
+            version11.apply(plan)
+            plan.withVariable('myMap', [key1:'value1', key2: 'value2'])
+            def result = plan.toString()
+
+            assertThat(result, containsString("-var 'myMap={key1=\"value1\",key2=\"value2\"}'"))
         }
     }
 
@@ -40,13 +52,25 @@ class TerraformPluginVersion11Test {
         @Test
         void toPreserveTerraform11CliSyntaxForVariables() {
             def applyCommand = new TerraformApplyCommand()
-            def version12 = new TerraformPluginVersion11()
+            def version11 = new TerraformPluginVersion11()
 
-            version12.apply(applyCommand)
+            version11.apply(applyCommand)
             applyCommand.withVariable('key', 'value')
             def result = applyCommand.toString()
 
             assertThat(result, containsString("-var 'key=value'"))
+        }
+
+        @Test
+        void toPreserveTerraform11CliFormatForMapVariables() {
+            def applyCommand = new TerraformPlanCommand()
+            def version11 = new TerraformPluginVersion11()
+
+            version11.apply(applyCommand)
+            applyCommand.withVariable('myMap', [key1:'value1', key2: 'value2'])
+            def result = applyCommand.toString()
+
+            assertThat(result, containsString("-var 'myMap={key1=\"value1\",key2=\"value2\"}'"))
         }
     }
 }

--- a/test/TerraformPluginVersion12Test.groovy
+++ b/test/TerraformPluginVersion12Test.groovy
@@ -45,6 +45,18 @@ class TerraformPluginVersion12Test {
 
             assertThat(result, containsString("-var='key=value'"))
         }
+
+        @Test
+        void toUseTerraform12CliFormatForMapVariables() {
+            def plan = new TerraformPlanCommand()
+            def version12 = new TerraformPluginVersion12()
+
+            version12.apply(plan)
+            plan.withVariable('myMap', [key1:'value1', key2: 'value2'])
+            def result = plan.toString()
+
+            assertThat(result, containsString("-var='myMap={\"key1\":\"value1\",\"key2\":\"value2\"}'"))
+        }
     }
 
     class ModifiesTerraformApplyCommand {
@@ -58,6 +70,18 @@ class TerraformPluginVersion12Test {
             def result = applyCommand.toString()
 
             assertThat(result, containsString("-var='key=value'"))
+        }
+
+        @Test
+        void toUseTerraform12CliFormatForMapVariables() {
+            def applyCommand = new TerraformApplyCommand()
+            def version12 = new TerraformPluginVersion12()
+
+            version12.apply(applyCommand)
+            applyCommand.withVariable('myMap', [key1:'value1', key2: 'value2'])
+            def result = applyCommand.toString()
+
+            assertThat(result, containsString("-var='myMap={\"key1\":\"value1\",\"key2\":\"value2\"}'"))
         }
     }
 }

--- a/test/TerraformPluginVersion12Test.groovy
+++ b/test/TerraformPluginVersion12Test.groovy
@@ -32,5 +32,33 @@ class TerraformPluginVersion12Test {
             verify(validateStage).decorate(eq(TerraformValidateStage.VALIDATE), any())
         }
     }
+
+    class ModifiesTerraformPlanCommand {
+        @Test
+        void toUseTerraform12CliSyntaxForVariables() {
+            def plan = new TerraformPlanCommand()
+            def version12 = new TerraformPluginVersion12()
+
+            version12.apply(plan)
+            plan.withVariable('key', 'value')
+            def result = plan.toString()
+
+            assertThat(result, containsString("-var='key=value'"))
+        }
+    }
+
+    class ModifiesTerraformApplyCommand {
+        @Test
+        void toUseTerraform12CliSyntaxForVariables() {
+            def applyCommand = new TerraformApplyCommand()
+            def version12 = new TerraformPluginVersion12()
+
+            version12.apply(applyCommand)
+            applyCommand.withVariable('key', 'value')
+            def result = applyCommand.toString()
+
+            assertThat(result, containsString("-var='key=value'"))
+        }
+    }
 }
 


### PR DESCRIPTION
* Issue #289 
* the syntax for passing variables through the CLI changed between 0.11.x and 0.12.x
* Fix the TagPlugin so that it automatically works with either version.