### PR TITLE
Issue 296: Optionally disable CLI variables on apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #296](https://github.com/manheim/terraform-pipeline/issues/296) Allow TagPlugin to be disabled on apply
 * [Issue #293](https://github.com/manheim/terraform-pipeline/issues/293) withEnv & withGlobalEnv docs
 * [Issue #175](https://github.com/manheim/terraform-pipeline/issues/175) Pass terraform plan output to apply
 

--- a/docs/TagPlugin.md
+++ b/docs/TagPlugin.md
@@ -82,3 +82,34 @@ validate.then(deployQa)
 ```
 
 
+If using a plan file, you can disable passing variables on the CLI for that command.
+
+```
+// Jenkinsfile
+@Library(['terraform-pipeline']) _
+
+Jenkinsfile.init(this, env)
+TagPlugin.withTag('simple', 'sometag') // Simple static tags
+         .withTag('repo', Jenkinsfile.instance.getScmUrl()) // Dynamic tags from your git configuration
+         .withEnvironmentTag('environment') // Dynamic tags from TerraformEnvironmentStage
+         .withTagFromEnvironmentVariable('team', 'TEAM') // Dynamic tags from an environment variable
+         .withTagFromFile('changeId', 'change-id.txt') // Dynamic tags from file
+         .disableOnApply()
+         .init()
+
+def validate = new TerraformValidateStage()
+
+// Tag variables only passsed on plan, and skipped on apply
+// -var='tags={"simple":"sometag","repo":"<repo>","environment":"qa","team":"<team>","changeId":"<changeId>"}'
+def deployQa = new TerraformEnvironmentStage('qa')
+// -var='tags={"simple":"sometag","repo":"<repo>","environment":"uat","team":"<team>","changeId":"<changeId>"}'
+def deployUat = new TerraformEnvironmentStage('uat')
+// -var='tags={"simple":"sometag","repo":"<repo>","environment":"prod","team":"<team>","changeId":"<changeId>"}'
+def deployProd = new TerraformEnvironmentStage('prod')
+
+validate.then(deployQa)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```
+

--- a/src/TagPlugin.groovy
+++ b/src/TagPlugin.groovy
@@ -2,6 +2,7 @@ class TagPlugin implements TerraformPlanCommandPlugin,
                            TerraformApplyCommandPlugin {
 
     private static variableName
+    private static disableOnApply = false
     private static List tagClosures = []
 
     public static init() {
@@ -18,6 +19,10 @@ class TagPlugin implements TerraformPlanCommandPlugin,
 
     @Override
     public void apply(TerraformApplyCommand command) {
+        if (disableOnApply) {
+            return
+        }
+
         applyToCommand(command)
     }
 
@@ -68,6 +73,10 @@ class TagPlugin implements TerraformPlanCommandPlugin,
         return this
     }
 
+    public static disableOnApply() {
+        disableOnApply = true
+    }
+
     private static getVariableName() {
         return variableName ?: 'tags'
     }
@@ -81,5 +90,6 @@ class TagPlugin implements TerraformPlanCommandPlugin,
     public static reset() {
         tagClosures = []
         variableName = null
+        disableOnApply = false
     }
 }

--- a/src/TagPlugin.groovy
+++ b/src/TagPlugin.groovy
@@ -75,6 +75,7 @@ class TagPlugin implements TerraformPlanCommandPlugin,
 
     public static disableOnApply() {
         disableOnApply = true
+        return this
     }
 
     private static getVariableName() {

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -261,4 +261,13 @@ class TagPluginTest {
             assertEquals([key1: 'value1', environment: 'myenv', key2: 'value2'], result)
         }
     }
+
+    class DisableOnApply {
+        @Test
+        void isFluent() {
+            def result = TagPlugin.disableOnApply()
+
+            assertEquals(result, TagPlugin.class)
+        }
+    }
 }

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.anyMap;
 
 import org.junit.Test
 import org.junit.Before
@@ -120,6 +123,17 @@ class TagPluginTest {
             plugin.apply(command)
 
             verify(command).withVariable(expectedVariableName, expectedTags)
+        }
+
+        @Test
+        public void doesNotAddVariablesWhenPluginIsDisabled() {
+            def command = spy(new TerraformApplyCommand())
+            def plugin = new TagPlugin()
+
+            TagPlugin.disableOnApply()
+            plugin.apply(command)
+
+            verify(command, times(0)).withVariable(anyString(), anyMap())
         }
 
         class WithVariableName {


### PR DESCRIPTION
* When you use a plan file, terraform apply will error if you pass variables on the CLI
* Allow variables to be skipped on apply, to allow for the use of plan files.