### PR TITLE
Issue 300: Trim whitespace when detecting terraform version from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* [Issue #300](https://github.com/manheim/terraform-pipeline/issues/300) Trim whitespace when detecting terraform version from file.
+
 # v5.11
 
 * [Issue #83](https://github.com/manheim/terraform-pipeline/issues/83) Add a plugin to support `terraform fmt`

--- a/src/TerraformPlugin.groovy
+++ b/src/TerraformPlugin.groovy
@@ -30,7 +30,7 @@ class TerraformPlugin implements TerraformValidateCommandPlugin,
     }
 
     public String detectVersion() {
-        version = version ?: Jenkinsfile.original.readFile(TERRAFORM_VERSION_FILE) ?: DEFAULT_VERSION
+        version = version ?: Jenkinsfile.readFile(TERRAFORM_VERSION_FILE) ?: DEFAULT_VERSION
 
         return version
     }

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -40,7 +40,22 @@ class TerraformPluginTest {
             def expectedVersion =  '0.12.0-foobar'
             def plugin = new TerraformPlugin()
             def original = spy(new DummyJenkinsfile())
+            doReturn(true).when(original).fileExists(TerraformPlugin.TERRAFORM_VERSION_FILE)
             doReturn(expectedVersion).when(original).readFile(TerraformPlugin.TERRAFORM_VERSION_FILE)
+            Jenkinsfile.original = original
+
+            def foundVersion = plugin.detectVersion()
+
+            assertEquals(expectedVersion, foundVersion)
+        }
+
+        @Test
+        void trimsWhitespaceFromFile() {
+            def expectedVersion =  '0.12.0-foobar'
+            def plugin = new TerraformPlugin()
+            def original = spy(new DummyJenkinsfile())
+            doReturn(true).when(original).fileExists(TerraformPlugin.TERRAFORM_VERSION_FILE)
+            doReturn("${expectedVersion}   ").when(original).readFile(TerraformPlugin.TERRAFORM_VERSION_FILE)
             Jenkinsfile.original = original
 
             def foundVersion = plugin.detectVersion()
@@ -52,7 +67,7 @@ class TerraformPluginTest {
         void usesDefaultIfFileNotFound() {
             def plugin = new TerraformPlugin()
             def original = spy(new DummyJenkinsfile())
-            doReturn(null).when(original).readFile(TerraformPlugin.TERRAFORM_VERSION_FILE)
+            doReturn(false).when(original).fileExists(TerraformPlugin.TERRAFORM_VERSION_FILE)
             Jenkinsfile.original = original
 
             def foundVersion = plugin.detectVersion()


### PR DESCRIPTION
* This was a regression, introduced by v5.12
* I was attempting to refactor and conslidate the duplicate readFile logic, and used the wrong method.