### PR TITLE
Issue #311: non-deterministic test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* [Issue #311](https://github.com/manheim/terraform-pipeline/issues/311) Fix non-deterministic test failures
+
+# v5.12
+
 * [Issue #303](https://github.com/manheim/terraform-pipeline/issues/303) Update ValidateFormatPlugin Documentation - additional options command
 * [Issue #300](https://github.com/manheim/terraform-pipeline/issues/300) Trim whitespace when detecting terraform version from file.
 * [Issue #299](https://github.com/manheim/terraform-pipeline/issues/299) Support for Global AWS Parameter Store

--- a/test/FileParametersPluginTest.groovy
+++ b/test/FileParametersPluginTest.groovy
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import de.bechte.junit.runners.context.HierarchicalContextRunner
@@ -28,6 +29,16 @@ class FileParametersPluginTest {
     }
 
     public class GetVariables {
+        @Before
+        void setupJenkinsfile() {
+            Jenkinsfile.original = new DummyJenkinsfile()
+        }
+
+        @After
+        void reset() {
+            Jenkinsfile.reset()
+        }
+
         @Test
         void returnsAValueForEachLine() {
             List expectedValues = [ "VAR1=VALUE1", "VAR2=VALUE2" ]

--- a/test/FileParametersPluginTest.groovy
+++ b/test/FileParametersPluginTest.groovy
@@ -2,7 +2,7 @@ import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertThat
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import org.junit.After
@@ -66,7 +66,7 @@ class FileParametersPluginTest {
             String fileContents = 'SOME_VARIABLE=${env.OTHER_VARIABLE}'
 
             FileParametersPlugin plugin = spy(new FileParametersPlugin())
-            when(plugin.getEnv()).thenReturn([ OTHER_VARIABLE: 'VALUE1'])
+            doReturn([ OTHER_VARIABLE: 'VALUE1']).when(plugin).getEnv()
 
             List actualValues = plugin.getVariables(fileContents)
 

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -154,6 +154,11 @@ class TagPluginTest {
     }
 
     public class GetTags {
+        @After
+        public void reset() {
+            Jenkinsfile.reset()
+        }
+
         @Test
         void returnsAndEmptyMapIfNoKeyValuePairsWereAdded() {
             def plugin = new TagPlugin()


### PR DESCRIPTION
Issue #311 
* Mockito spies use different stub syntax.  `getEnv` should be stubbed, but is getting incorrectly called instead.  Use the correct stubbing syntax so that the underlying method is not called.
* Identify and fix the test that was not cleaning up after itself (Answer: TagPluginTest)
* Fix FileParametersPlugin - it's accessing global environment variables, and therefore expects `Jenkinsfile.original` to be stubbed.