### PR TITLE
Fixes #316 - implement more granular decorations in TerraformEnvironmentStage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * [Issue #311](https://github.com/manheim/terraform-pipeline/issues/311) Fix non-deterministic test failures
+* [Issue #316](https://github.com/manheim/terraform-pipeline/issues/316) Implement more granular decorations in TerraformEnvironmentStage.
 
 # v5.12
 

--- a/docs/TerraformEnvironmentStage.md
+++ b/docs/TerraformEnvironmentStage.md
@@ -42,3 +42,9 @@ validate.then(deployQA)
         .then(deployProd)
         .build()
 ```
+
+### For Plugin Developers
+
+#### Decorate Stages/Commands or Hook before/after command execution
+
+TerraformEnvironmentStage has support for numerous decorators, to allow wrapping the various stages, steps, and individual commands. Please see the [source code](../src/TerraformEnvironmentStage.groovy) for details.

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -9,9 +9,12 @@ class TerraformEnvironmentStage implements Stage, DecoratableStage {
     private static Closure stageNamePattern
 
     public static final String ALL = 'all'
+    public static final String INIT_COMMAND = 'init-command'
     public static final String PLAN = 'plan'
+    public static final String PLAN_COMMAND = 'plan-command'
     public static final String CONFIRM = 'confirm'
     public static final String APPLY = 'apply'
+    public static final String APPLY_COMMAND = 'apply-command'
 
     TerraformEnvironmentStage(String environment) {
         this.environment = environment
@@ -60,8 +63,12 @@ class TerraformEnvironmentStage implements Stage, DecoratableStage {
                 decorations.apply(ALL) {
                     stage(getStageNameFor(PLAN)) {
                         decorations.apply(PLAN) {
-                            sh initCommand.toString()
-                            sh planCommand.toString()
+                            decorations.apply(INIT_COMMAND) {
+                              sh initCommand.toString()
+                            }
+                            decorations.apply(PLAN_COMMAND) {
+                              sh planCommand.toString()
+                            }
                         }
                     }
 
@@ -78,8 +85,12 @@ class TerraformEnvironmentStage implements Stage, DecoratableStage {
                         // The stage name needs to be editable
                         stage(getStageNameFor(APPLY)) {
                             decorations.apply(APPLY) {
-                                sh initCommand.toString()
-                                sh applyCommand.toString()
+                                decorations.apply(INIT_COMMAND) {
+                                  sh initCommand.toString()
+                                }
+                                decorations.apply(APPLY_COMMAND) {
+                                  sh applyCommand.toString()
+                                }
                             }
                         }
                     }

--- a/src/TerraformEnvironmentStage.groovy
+++ b/src/TerraformEnvironmentStage.groovy
@@ -64,10 +64,10 @@ class TerraformEnvironmentStage implements Stage, DecoratableStage {
                     stage(getStageNameFor(PLAN)) {
                         decorations.apply(PLAN) {
                             decorations.apply(INIT_COMMAND) {
-                              sh initCommand.toString()
+                                sh initCommand.toString()
                             }
                             decorations.apply(PLAN_COMMAND) {
-                              sh planCommand.toString()
+                                sh planCommand.toString()
                             }
                         }
                     }
@@ -86,10 +86,10 @@ class TerraformEnvironmentStage implements Stage, DecoratableStage {
                         stage(getStageNameFor(APPLY)) {
                             decorations.apply(APPLY) {
                                 decorations.apply(INIT_COMMAND) {
-                                  sh initCommand.toString()
+                                    sh initCommand.toString()
                                 }
                                 decorations.apply(APPLY_COMMAND) {
-                                  sh applyCommand.toString()
+                                    sh applyCommand.toString()
                                 }
                             }
                         }


### PR DESCRIPTION
This PR adds some more-granular decorators around the shell commands run in TerraformEnvironmentStage (init, plan, and apply). This provides an extension point for a future plugin to allow executing shell commands (hooks) before and/or after each of these commands.

Please note that I have not (yet?) added unit tests for this. As far as I can tell the current code does not have tests for anything in the closure, aside from it not blowing up, and I'm not entirely sure how to test this...