### PR TITLE
Issue 321: Upgrade groovy from 2.4.11 to 2.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #321](https://github.com/manheim/terraform-pipeline/issues/321) Upgrade groovy from 2.4.11 to 2.4.12 (fix travisCi failures)
 * [Issue #311](https://github.com/manheim/terraform-pipeline/issues/311) Fix non-deterministic test failures
 * [Issue #316](https://github.com/manheim/terraform-pipeline/issues/316) Implement more granular decorations in TerraformEnvironmentStage.
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.11'
+    compile 'org.codehaus.groovy:groovy-all:2.4.12'
 
     testCompile 'com.lesfurets:jenkins-pipeline-unit:1.1'
 


### PR DESCRIPTION
* Issue #321 
* PR #250 has a compile error in travisCI
* Groovy 2.4.12 has a fix for the problem, and solves the failing travisCI builds