### PR TITLE
Doc Fix: TerraformEnvironmentStageShellHookPlugin typos

### DIFF
--- a/docs/TerraformEnvironmentStageShellHookPlugin.md
+++ b/docs/TerraformEnvironmentStageShellHookPlugin.md
@@ -18,7 +18,7 @@ Each hook point "wraps" various parts of the Stage, and supports a total of four
 
 ```
 // Jenkinsfile
-@Library(['terraform-pipeline@v']) _
+@Library(['terraform-pipeline']) _
 
 Jenkinsfile.init(this)
 

--- a/docs/TerraformEnvironmentStageShellHookPlugin.md
+++ b/docs/TerraformEnvironmentStageShellHookPlugin.md
@@ -22,8 +22,8 @@ Each hook point "wraps" various parts of the Stage, and supports a total of four
 
 Jenkinsfile.init(this)
 
-TerraformEnvironmentStageShellHookPlugin.withHook(TerraformEnvironmentStage.APPLY, './bin/after_successful_apply.sh')
-                                        .withHook(TerraformEnvironmentStage.INIT, './bin/download_deps.sh', WhenToRun.BEFORE)
+TerraformEnvironmentStageShellHookPlugin.withHook(TerraformEnvironmentStage.APPLY_COMMAND, './bin/after_successful_apply.sh')
+                                        .withHook(TerraformEnvironmentStage.INIT_COMMAND, './bin/download_deps.sh', WhenToRun.BEFORE)
                                         .withHook(TerraformEnvironmentStage.ALL, './bin/cleanup.sh', WhenToRun.AFTER)
                                         .init()
 


### PR DESCRIPTION
* Issue #250 
* Fix hook point constants `INIT` -> `INIT_COMMAND`, `APPLY` -> `APPLY_COMMAND`
* Fix version in library - default to no version, since we don't want to have to update it all the time