### PR TITLE
Issue 332: Upgrade to Junit 5, hamcrest 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* [Issue #332](https://github.com/manheim/terraform-pipeline/issues/332) Upgrade from Junit 4 to 5.7, upgrade hamcrest from 1.3 to 2.2, remove junit-hierarchicalcontextrunner dependency
+
 # v5.14
 
 * [Issue #25](https://github.com/manheim/terraform-pipeline/issues/25) Allow 'apply' on branches other than master for some environments

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.0'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.0'
     testCompile group: 'com.cyrusinnovation', name: 'mockito-groovy-support', version: '1.3'
-    testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,14 @@ dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.12'
 
     testCompile 'com.lesfurets:jenkins-pipeline-unit:1.1'
-
-    testCompile 'junit:junit:4.11'
-    testCompile group: 'de.bechte.junit', name: 'junit-hierarchicalcontextrunner', version: '4.11.1'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.0'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.0'
     testCompile group: 'com.cyrusinnovation', name: 'mockito-groovy-support', version: '1.3'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 sourceSets {

--- a/test/AgentNodePluginTest.groovy
+++ b/test/AgentNodePluginTest.groovy
@@ -1,6 +1,6 @@
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.contains;
@@ -10,13 +10,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Test
-import org.junit.After
-import org.junit.Before
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class AgentNodePluginTest {
     private createJenkinsfileSpy() {
         def dummyJenkinsfile = spy(new DummyJenkinsfile())
@@ -25,8 +23,9 @@ class AgentNodePluginTest {
         return dummyJenkinsfile
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformValidateStage.resetPlugins()
             TerraformEnvironmentStage.reset()
@@ -49,6 +48,7 @@ class AgentNodePluginTest {
         }
     }
 
+    @Nested
     class Apply {
         @Test
         void addsAgentClosureToTerraformEnvironmentStage() {
@@ -75,7 +75,9 @@ class AgentNodePluginTest {
         }
     }
 
+    @Nested
     class AddAgent {
+        @Nested
         class WithNoDockerEnabled {
             @Test
             void callsTheInnerclosure() {
@@ -90,14 +92,15 @@ class AgentNodePluginTest {
             }
         }
 
+        @Nested
         class WithDockerImageNoDockerfile {
             private String expectedImage = 'someImage'
-            @Before
+            @BeforeEach
             void useDockerImage() {
                 AgentNodePlugin.withAgentDockerImage(expectedImage)
             }
 
-            @After
+            @AfterEach
             void reset() {
                 AgentNodePlugin.reset()
             }
@@ -142,14 +145,15 @@ class AgentNodePluginTest {
             }
         }
 
+        @Nested
         class WithDockerImageAndDockerfile {
             private String expectedImage = 'someImage'
-            @Before
+            @BeforeEach
             void useDockerImage() {
                 AgentNodePlugin.withAgentDockerImage(expectedImage)
             }
 
-            @After
+            @AfterEach
             void reset() {
                 AgentNodePlugin.reset()
             }

--- a/test/AnsiColorPluginTest.groovy
+++ b/test/AnsiColorPluginTest.groovy
@@ -1,16 +1,15 @@
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
 
-import org.junit.Test
-import org.junit.After
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class AnsiColorPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformEnvironmentStage.reset()
         }

--- a/test/AwssumePluginTest.groovy
+++ b/test/AwssumePluginTest.groovy
@@ -3,19 +3,17 @@ import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.is
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class AwssumePluginTest {
-    @Before
+    @BeforeEach
     void resetJenkinsEnv() {
         Jenkinsfile.instance = mock(Jenkinsfile.class)
         when(Jenkinsfile.instance.getEnv()).thenReturn([:])
@@ -27,8 +25,9 @@ class AwssumePluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformInitCommand.resetPlugins()
             TerraformPlanCommand.resetPlugins()
@@ -60,8 +59,10 @@ class AwssumePluginTest {
         }
     }
 
+    @Nested
     public class Apply {
 
+        @Nested
         public class WithRoleProvided {
             @Test
             void addsEnvironmentSpecificRoleArnAsPrefixToTerraformInit() {
@@ -103,6 +104,7 @@ class AwssumePluginTest {
             }
         }
 
+        @Nested
         public class WithoutRoleProvided {
             @Test
             void skipsAwssumeForTerraformInit() {
@@ -148,6 +150,7 @@ class AwssumePluginTest {
         }
     }
 
+    @Nested
     public class GetAwsRoleArn {
         @Test
         void returnsAwsRoleArnIfPresent() {
@@ -197,6 +200,7 @@ class AwssumePluginTest {
         }
     }
 
+    @Nested
     public class GetRegion {
         @Test
         void returnsAwsRegionIfPresent() {

--- a/test/BuildGraphTest.groovy
+++ b/test/BuildGraphTest.groovy
@@ -3,13 +3,12 @@ import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
 import org.mockito.InOrder
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class BuildGraphTest {
+    @Nested
     public class WithASingleStage {
         @Test
         void buildsTheStageThatItWasCreatedWith() {
@@ -22,6 +21,7 @@ class BuildGraphTest {
         }
     }
 
+    @Nested
     public class WithMultipleStages {
         @Test
         void buildsTheStagesInOrder() {

--- a/test/BuildStageTest.groovy
+++ b/test/BuildStageTest.groovy
@@ -1,16 +1,15 @@
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.doReturn
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class BuildStageTest {
 
+    @Nested
     public class Build {
-        @After
+        @AfterEach
         void reset() {
             Jenkinsfile.original = null
         }

--- a/test/BuildWithParametersPluginTest.groovy
+++ b/test/BuildWithParametersPluginTest.groovy
@@ -1,10 +1,10 @@
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -12,16 +12,14 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Test
-import org.junit.After
-import org.junit.Before
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class BuildWithParametersPluginTest {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     void reset() {
         BuildWithParametersPlugin.reset()
     }
@@ -33,8 +31,9 @@ class BuildWithParametersPluginTest {
         return dummyJenkinsfile
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             BuildStage.resetPlugins()
             TerraformValidateStage.resetPlugins()
@@ -75,6 +74,7 @@ class BuildWithParametersPluginTest {
         }
     }
 
+    @Nested
     class Apply {
         @Test
         void worksForBuildStage() {
@@ -125,7 +125,9 @@ class BuildWithParametersPluginTest {
         }
     }
 
+    @Nested
     class AddParameterToFirstStageOnly {
+        @Nested
         class WithNoParameters {
             @Test
             void runsTheInnerClosure() {
@@ -151,6 +153,7 @@ class BuildWithParametersPluginTest {
             }
         }
 
+        @Nested
         class WithParameters {
             @Test
             void runsTheInnerClosure() {
@@ -200,9 +203,10 @@ class BuildWithParametersPluginTest {
         }
     }
 
+    @Nested
     class HasParameters {
-        @Before
-        @After
+        @BeforeEach
+        @AfterEach
         void reset() {
             BuildWithParametersPlugin.reset()
         }
@@ -227,6 +231,7 @@ class BuildWithParametersPluginTest {
         }
     }
 
+    @Nested
     class WithBooleanParameter {
         @Test
         void usesTheGivenName() {
@@ -273,6 +278,7 @@ class BuildWithParametersPluginTest {
         }
     }
 
+    @Nested
     class WithStringParameter {
         @Test
         void usesTheGivenName() {
@@ -320,6 +326,7 @@ class BuildWithParametersPluginTest {
 
     }
 
+    @Nested
     class WithParameter {
         @Test
         void addsTheGivenParameter() {

--- a/test/ConditionalApplyPluginTest.groovy
+++ b/test/ConditionalApplyPluginTest.groovy
@@ -1,19 +1,17 @@
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class ConditionalApplyPluginTest {
-    @After
+    @AfterEach
     public void reset() {
         Jenkinsfile.instance = null
         ConditionalApplyPlugin.reset()
@@ -32,6 +30,7 @@ class ConditionalApplyPluginTest {
         assertThat(actualPlugins, hasItem(instanceOf(ConditionalApplyPlugin.class)))
     }
 
+    @Nested
     class ShouldApply {
         @Test
         void returnsTrueForMasterByDefault() {

--- a/test/ConfirmApplyPluginTest.groovy
+++ b/test/ConfirmApplyPluginTest.groovy
@@ -1,22 +1,21 @@
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class ConfirmApplyPluginTest {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     void reset() {
         ConfirmApplyPlugin.reset()
     }
@@ -42,6 +41,7 @@ class ConfirmApplyPluginTest {
         assertFalse(ConfirmApplyPlugin.enabled)
     }
 
+    @Nested
     class GetInputOptions {
         @Test
         void defaultsToASubmitterParameterOfApprover() {
@@ -109,6 +109,7 @@ class ConfirmApplyPluginTest {
         }
     }
 
+    @Nested
     class CheckConfirmConditions {
         @Test
         void doesNothingByDefault() {
@@ -127,14 +128,16 @@ class ConfirmApplyPluginTest {
             plugin.checkConfirmConditions('someInput', 'foo')
         }
 
-        @Test(expected = RuntimeException.class)
+        @Test
         void raisesAnExceptionIfAnyConditionReturnsFalse() {
             def plugin = new ConfirmApplyPlugin()
             ConfirmApplyPlugin.withConfirmCondition { options -> true }
                               .withConfirmCondition { options -> false }
                               .withConfirmCondition { options -> true }
 
-            plugin.checkConfirmConditions('someInput', 'foo')
+            assertThrows(RuntimeException.class) {
+                plugin.checkConfirmConditions('someInput', 'foo')
+            }
         }
 
         @Test
@@ -162,6 +165,7 @@ class ConfirmApplyPluginTest {
         }
     }
 
+    @Nested
     class WithParameter {
         @Test
         void isFluent() {
@@ -171,6 +175,7 @@ class ConfirmApplyPluginTest {
         }
     }
 
+    @Nested
     class WithConfirmMessage {
         @Test
         void isFluent() {
@@ -180,6 +185,7 @@ class ConfirmApplyPluginTest {
         }
     }
 
+    @Nested
     class WithOkMessage {
         @Test
         void isFluent() {
@@ -189,6 +195,7 @@ class ConfirmApplyPluginTest {
         }
     }
 
+    @Nested
     class WithSubmitterParameter {
         @Test
         void isFluent() {

--- a/test/ConsulBackendPluginTest.groovy
+++ b/test/ConsulBackendPluginTest.groovy
@@ -2,20 +2,19 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class ConsulBackendPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformInitCommand.resetPlugins()
         }
@@ -29,8 +28,9 @@ class ConsulBackendPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
-        @Before
+        @BeforeEach
         public void resetJenkinsfile() {
             Jenkinsfile.instance = mock(Jenkinsfile.class)
             when(Jenkinsfile.instance.getEnv()).thenReturn([:])
@@ -42,6 +42,7 @@ class ConsulBackendPluginTest {
             when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
         }
 
+        @Nested
         public class PathBackendParameter {
             @Test
             void isAddedAndIsEnvironmentSpecific() {
@@ -73,6 +74,7 @@ class ConsulBackendPluginTest {
             }
         }
 
+        @Nested
         public class AddressBackendParameter {
             @Test
             void isNotAddedByDefault() {

--- a/test/CredentialsPluginTest.groovy
+++ b/test/CredentialsPluginTest.groovy
@@ -4,21 +4,20 @@ import static org.hamcrest.Matchers.hasSize
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.is
 import static org.hamcrest.Matchers.notNullValue
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.any
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class CredentialsPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             BuildStage.resetPlugins()
             RegressionStage.resetPlugins()
@@ -55,8 +54,9 @@ class CredentialsPluginTest {
         }
     }
 
+    @Nested
     public class WithBuildCredentials {
-        @After
+        @AfterEach
         void resetPlugin() {
             CredentialsPlugin.reset()
         }
@@ -87,6 +87,7 @@ class CredentialsPluginTest {
         }
     }
 
+    @Nested
     public class ToEnvironmentVariable {
         @Test
         void convertsLowercaseToUppercase() {
@@ -116,6 +117,7 @@ class CredentialsPluginTest {
         }
     }
 
+    @Nested
     public class PopulateDefaults {
         @Test
         void populatesCredentialsId() {
@@ -165,6 +167,7 @@ class CredentialsPluginTest {
         }
     }
 
+    @Nested
     class Apply {
         @Test
         void decoratesTheBuildStage()  {

--- a/test/CrqPluginTest.groovy
+++ b/test/CrqPluginTest.groovy
@@ -1,21 +1,20 @@
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.is
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class CrqPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformEnvironmentStage.reset()
         }
@@ -29,7 +28,9 @@ class CrqPluginTest {
         }
     }
 
+    @Nested
     public class AddCrq {
+        @Nested
         public class withCrqEnvironment {
             @Test
             public void shouldExecutePipeline() {
@@ -49,6 +50,7 @@ class CrqPluginTest {
             // @Test shouldCallRemedierOpen
         }
 
+        @Nested
         public class withoutCrqEnvironment {
             @Test
             public void shouldExecutePipeline() {
@@ -67,6 +69,7 @@ class CrqPluginTest {
         }
     }
 
+    @Nested
     public class GetCrqEnviroment {
         @Test
         void returnsCrqEnvirommentIfPresent() {

--- a/test/DefaultEnvironmentPluginTest.groovy
+++ b/test/DefaultEnvironmentPluginTest.groovy
@@ -1,13 +1,12 @@
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class DefaultEnvironmentPluginTest {
+    @Nested
     public class Init {
         @Test
         void modifiesTerraformEnvironmentStageByDefault() {

--- a/test/DestroyPluginTest.groovy
+++ b/test/DestroyPluginTest.groovy
@@ -1,23 +1,21 @@
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
 
-import org.junit.Test
-import org.junit.Before
-import org.junit.After
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class DestroyPluginTest {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     void reset() {
         Jenkinsfile.reset()
         ConfirmApplyPlugin.reset()
@@ -26,8 +24,9 @@ class DestroyPluginTest {
         TerraformApplyCommand.resetPlugins()
     }
 
+    @Nested
     public class Init {
-        @Before
+        @BeforeEach
         void setup() {
             Jenkinsfile.instance = mock(Jenkinsfile.class)
             doReturn('repoName').when(Jenkinsfile.instance).getRepoName()
@@ -71,6 +70,7 @@ class DestroyPluginTest {
         }
     }
 
+    @Nested
     class ApplyTerraformPlanCommand {
         @Test
         void modifiesPlanToIncludeDestroyArgument() {
@@ -84,6 +84,7 @@ class DestroyPluginTest {
         }
     }
 
+    @Nested
     class ApplyTerraformApplyCommand {
         @Test
         void modifiesCommandFromApplyToDestroy() {
@@ -96,8 +97,9 @@ class DestroyPluginTest {
             assertThat(result, containsString('terraform destroy'))
         }
 
+        @Nested
         class WithArguments {
-            @After
+            @AfterEach
             void resetPlugins() {
                 DestroyPlugin.reset()
             }
@@ -133,6 +135,7 @@ class DestroyPluginTest {
         }
     }
 
+    @Nested
     class WithArgument {
         @Test
         void isFluent() {
@@ -142,6 +145,7 @@ class DestroyPluginTest {
         }
     }
 
+    @Nested
     class ConfirmCondition {
         @Test
         void returnsTrueIfConfirmationInputDoesNotMatch() {

--- a/test/FileParametersPluginTest.groovy
+++ b/test/FileParametersPluginTest.groovy
@@ -1,20 +1,19 @@
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class FileParametersPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformEnvironmentStage.reset()
         }
@@ -28,13 +27,14 @@ class FileParametersPluginTest {
         }
     }
 
+    @Nested
     public class GetVariables {
-        @Before
+        @BeforeEach
         void setupJenkinsfile() {
             Jenkinsfile.original = new DummyJenkinsfile()
         }
 
-        @After
+        @AfterEach
         void reset() {
             Jenkinsfile.reset()
         }

--- a/test/GithubPRPlanPlugin.groovy
+++ b/test/GithubPRPlanPlugin.groovy
@@ -1,11 +1,11 @@
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -17,16 +17,14 @@ import static org.mockito.Mockito.times;
 import static TerraformEnvironmentStage.PLAN;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test
-import org.junit.Before
-import org.junit.After
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class GithubPRPlanPluginTest {
 
-    @Before
+    @BeforeEach
     void resetJenkinsEnv() {
         Jenkinsfile.instance = mock(Jenkinsfile.class)
         when(Jenkinsfile.instance.getEnv()).thenReturn([:])
@@ -38,8 +36,9 @@ class GithubPRPlanPluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformPlanCommand.resetPlugins()
             TerraformEnvironmentStage.reset()
@@ -62,6 +61,7 @@ class GithubPRPlanPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
 
         @Test
@@ -92,8 +92,9 @@ class GithubPRPlanPluginTest {
 
     }
 
+    @Nested
     class GetRepoSlug {
-        @After
+        @AfterEach
         void resetPlugin() {
             GithubPRPlanPlugin.reset()
             Jenkinsfile.reset()
@@ -126,14 +127,15 @@ class GithubPRPlanPluginTest {
 
     }
 
+    @Nested
     class GetRepoHost {
-        @Before
+        @BeforeEach
         void resetBefore() {
             GithubPRPlanPlugin.reset()
             Jenkinsfile.reset()
         }
 
-        @After
+        @AfterEach
         void reset() {
             GithubPRPlanPlugin.reset()
             Jenkinsfile.reset()
@@ -187,6 +189,7 @@ class GithubPRPlanPluginTest {
         }
     }
 
+    @Nested
     class IsPullRequest {
         @Test
         void returnsTrueWhenBranchNameStartsWithPR() {
@@ -206,6 +209,7 @@ class GithubPRPlanPluginTest {
 
     }
 
+    @Nested
     class GetPullRequestNumber {
         @Test
         void parsesTheNumberFromTheBranchName() {
@@ -219,6 +223,7 @@ class GithubPRPlanPluginTest {
         }
     }
 
+    @Nested
     class GetPullRequestCommentUrl {
         @Test
         void constructsTheUrlFromHostRepoSlugAndPrNumber() {
@@ -236,6 +241,7 @@ class GithubPRPlanPluginTest {
         }
     }
 
+    @Nested
     class GetPlanOutput {
         @Test
         void readsContentsFromPlanOutFile() {
@@ -273,6 +279,7 @@ class GithubPRPlanPluginTest {
             assertThat(planOutput, not(containsString(colorEncoding)))
         }
 
+        @Nested
         class WithErrorOutput {
             @Test
             void includesContentsFromPlanErrorFileIfPresent() {
@@ -326,6 +333,7 @@ class GithubPRPlanPluginTest {
         }
     }
 
+    @Nested
     class GetCommentBody {
         @Test
         void usesThePlanOutput()  {
@@ -380,13 +388,14 @@ class GithubPRPlanPluginTest {
         }
     }
 
+    @Nested
     class PostPullRequestComment {
-        @After
+        @AfterEach
         void reset() {
             Jenkinsfile.reset()
         }
 
-        @Before
+        @BeforeEach
         void stubJenkins() {
             Jenkinsfile.original = spy(new DummyJenkinsfile())
         }

--- a/test/HookPointTest.groovy
+++ b/test/HookPointTest.groovy
@@ -1,6 +1,6 @@
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.mockito.Mockito.inOrder
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.times
@@ -8,14 +8,13 @@ import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.verifyNoMoreInteractions
 
 import org.mockito.InOrder
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class HookPointTest {
 
+    @Nested
     public class Constructor {
         @Test
         void setsHookName() {
@@ -24,6 +23,7 @@ class HookPointTest {
         }
     }
 
+    @Nested
     public class IsConfigured {
         @Test
         void falseIfAllNull() {
@@ -60,8 +60,9 @@ class HookPointTest {
         }
     }
 
+    @Nested
     public class GetClosure {
-        @After
+        @AfterEach
         public void reset() {
             Jenkinsfile.instance = null
             TerraformEnvironmentStage.reset()

--- a/test/JenkinsfileTest.groovy
+++ b/test/JenkinsfileTest.groovy
@@ -1,7 +1,8 @@
 import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.startsWith
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
@@ -9,27 +10,26 @@ import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class JenkinsfileTest {
     private Jenkinsfile jenkinsfile
 
-    @Before
+    @BeforeEach
     public void setup() {
         jenkinsfile = new Jenkinsfile()
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     void reset() {
         Jenkinsfile.reset()
     }
 
+    @Nested
     class StandardizedRepoSlug {
         @Test
         void startsWithTheRepoOrganization() {
@@ -80,15 +80,18 @@ class JenkinsfileTest {
         }
     }
 
+    @Nested
     public class ParseScmUrl {
+        @Nested
         public class WithHttpUrl {
+            @Nested
             public class WithHttp {
                 @Test
                 void returnsOrganization() {
                     String organization = "MyOrg"
                     Map results = jenkinsfile.parseScmUrl("http://my.github.com/${organization}/SomeRepo.git")
 
-                    assertEquals(organization, results['organization'])
+                    assertThat(results['organization'], equalTo(organization))
                 }
 
                 @Test
@@ -96,7 +99,7 @@ class JenkinsfileTest {
                     String repo = "MyRepo"
                     Map results = jenkinsfile.parseScmUrl("http://my.github.com/SomeOrg/${repo}.git")
 
-                    assertEquals(repo, results['repo'])
+                    assertThat(results['repo'], equalTo(repo))
                 }
 
                 @Test
@@ -104,7 +107,7 @@ class JenkinsfileTest {
                     String expectedDomain = "my.github.com"
                     Map results = jenkinsfile.parseScmUrl("http://${expectedDomain}/SomeOrg/SomeRepo.git")
 
-                    assertEquals(expectedDomain, results['domain'])
+                    assertThat(results['domain'], equalTo(expectedDomain))
                 }
 
                 @Test
@@ -112,17 +115,18 @@ class JenkinsfileTest {
                     String expectedProtocol = "http"
                     Map results = jenkinsfile.parseScmUrl("${expectedProtocol}://my.github.com/SomeOrg/SomeRepo.git")
 
-                    assertEquals(expectedProtocol, results['protocol'])
+                    assertThat(results['protocol'], equalTo(expectedProtocol))
                 }
             }
 
+            @Nested
             public class WithHttps {
                 @Test
                 void returnsOrganization() {
                     String organization = "MyOrg"
                     Map results = jenkinsfile.parseScmUrl("https://my.github.com/${organization}/SomeRepo.git")
 
-                    assertEquals(organization, results['organization'])
+                    assertThat(results['organization'], equalTo(organization))
                 }
 
                 @Test
@@ -130,7 +134,7 @@ class JenkinsfileTest {
                     String repo = "MyRepo"
                     Map results = jenkinsfile.parseScmUrl("https://my.github.com/SomeOrg/${repo}.git")
 
-                    assertEquals(repo, results['repo'])
+                    assertThat(results['repo'], equalTo(repo))
                 }
 
                 @Test
@@ -138,7 +142,7 @@ class JenkinsfileTest {
                     String expectedDomain = "my.github.com"
                     Map results = jenkinsfile.parseScmUrl("https://${expectedDomain}/SomeOrg/SomeRepo.git")
 
-                    assertEquals(expectedDomain, results['domain'])
+                    assertThat(results['domain'], equalTo(expectedDomain))
                 }
 
                 @Test
@@ -146,18 +150,19 @@ class JenkinsfileTest {
                     String expectedProtocol = "https"
                     Map results = jenkinsfile.parseScmUrl("${expectedProtocol}://my.github.com/SomeOrg/SomeRepo.git")
 
-                    assertEquals(expectedProtocol, results['protocol'])
+                    assertThat(results['protocol'], equalTo(expectedProtocol))
                 }
             }
         }
 
+        @Nested
         public class WithSshUrl {
             @Test
             void returnsOrganization() {
                 String organization = "MyOrg"
                 Map results = jenkinsfile.parseScmUrl("git@my.github.com:${organization}/SomeRepo.git")
 
-                assertEquals(organization, results['organization'])
+                assertThat(results['organization'], equalTo(organization))
             }
 
             @Test
@@ -165,7 +170,7 @@ class JenkinsfileTest {
                 String repo = "MyRepo"
                 Map results = jenkinsfile.parseScmUrl("git@my.github.com:SomeOrg/${repo}.git")
 
-                assertEquals(repo, results['repo'])
+                assertThat(results['repo'], equalTo(repo))
             }
 
             @Test
@@ -173,7 +178,7 @@ class JenkinsfileTest {
                 String expectedDomain = "my.github.com"
                 Map results = jenkinsfile.parseScmUrl("git@${expectedDomain}/SomeOrg/SomeRepo.git")
 
-                assertEquals(expectedDomain, results['domain'])
+                assertThat(results['domain'], equalTo(expectedDomain))
             }
 
             @Test
@@ -181,11 +186,12 @@ class JenkinsfileTest {
                 String expectedProtocol = 'git'
                 Map results = jenkinsfile.parseScmUrl("${expectedProtocol}@my.github.com/SomeOrg/SomeRepo.git")
 
-                assertEquals(expectedProtocol, results['protocol'])
+                assertThat(results['protocol'], equalTo(expectedProtocol))
             }
         }
     }
 
+    @Nested
     public class GetRepoName {
         @Test
         void returnsTheUnmodifiedRepoName() {
@@ -196,10 +202,11 @@ class JenkinsfileTest {
             def instance = new Jenkinsfile()
             def result = instance.getRepoName()
 
-            assertEquals(expectedRepo, result)
+            assertThat(result, equalTo(expectedRepo))
         }
     }
 
+    @Nested
     public class GetOrganization {
         @Test
         void returnsTheUnmodifiedOrgName() {
@@ -210,25 +217,28 @@ class JenkinsfileTest {
             def instance = new Jenkinsfile()
             def result = instance.getOrganization()
 
-            assertEquals(expectedOrg, result)
+            assertThat(result, equalTo(expectedOrg))
         }
     }
 
+    @Nested
     public class Init {
         @Test
         void storesTheOriginalJenkinsfileReference() {
             def original = new DummyJenkinsfile()
             Jenkinsfile.init(original)
 
-            assertEquals(original, Jenkinsfile.original)
+            assertThat(Jenkinsfile.original, equalTo(original))
         }
     }
 
+    @Nested
     public class Build {
         private class DummyJenkinsfileWithTemplates extends DummyJenkinsfile {
             public Pipeline2Stage = { args -> }
         }
 
+        @Nested
         class Scripted {
             @Test
             void usesDefaultTemplatesIfNonProvided() {
@@ -244,6 +254,7 @@ class JenkinsfileTest {
             }
         }
 
+        @Nested
         class Declarative {
             @Test
             void usesDefaultTemplatesIfNonProvided() {
@@ -272,6 +283,7 @@ class JenkinsfileTest {
         }
     }
 
+    @Nested
     class GetPipelineTemplate {
         private class DummyJenkinsfileWithTemplates extends DummyJenkinsfile {
             public Pipeline2Stage = { args -> }
@@ -291,11 +303,13 @@ class JenkinsfileTest {
             return stages
         }
 
-        @Test(expected = RuntimeException.class)
+        @Test
         void throwsAnErrorFor1Stage() {
             def stages = getNumberOfStages(1)
 
-            Jenkinsfile.getPipelineTemplate(stages)
+            assertThrows(RuntimeException.class) {
+                Jenkinsfile.getPipelineTemplate(stages)
+            }
         }
 
         @Test
@@ -306,7 +320,7 @@ class JenkinsfileTest {
 
             def actual = Jenkinsfile.getPipelineTemplate(stages)
 
-            assertEquals(original.Pipeline2Stage, actual)
+            assertThat(actual, equalTo(original.Pipeline2Stage))
         }
 
         @Test
@@ -317,7 +331,7 @@ class JenkinsfileTest {
 
             def actual = Jenkinsfile.getPipelineTemplate(stages)
 
-            assertEquals(original.Pipeline3Stage, actual)
+            assertThat(actual, equalTo(original.Pipeline3Stage))
         }
 
         @Test
@@ -328,7 +342,7 @@ class JenkinsfileTest {
 
             def actual = Jenkinsfile.getPipelineTemplate(stages)
 
-            assertEquals(original.Pipeline4Stage, actual)
+            assertThat(actual, equalTo(original.Pipeline4Stage))
         }
 
         @Test
@@ -339,7 +353,7 @@ class JenkinsfileTest {
 
             def actual = Jenkinsfile.getPipelineTemplate(stages)
 
-            assertEquals(original.Pipeline5Stage, actual)
+            assertThat(actual, equalTo(original.Pipeline5Stage))
         }
 
         @Test
@@ -350,7 +364,7 @@ class JenkinsfileTest {
 
             def actual = Jenkinsfile.getPipelineTemplate(stages)
 
-            assertEquals(original.Pipeline6Stage, actual)
+            assertThat(actual, equalTo(original.Pipeline6Stage))
         }
 
         @Test
@@ -361,10 +375,11 @@ class JenkinsfileTest {
 
             def actual = Jenkinsfile.getPipelineTemplate(stages)
 
-            assertEquals(original.Pipeline7Stage, actual)
+            assertThat(actual, equalTo(original.Pipeline7Stage))
         }
     }
 
+    @Nested
     class GetEnv {
         @Test
         void returnsThe7StageTemplateFor7Stages() {
@@ -376,13 +391,14 @@ class JenkinsfileTest {
 
             def actual = instance.getEnv()
 
-            assertEquals(expected, actual)
+            assertThat(actual, equalTo(expected))
         }
 
     }
 
+    @Nested
     public class GetNodeName {
-        @After
+        @AfterEach
         void reset() {
             Jenkinsfile.defaultNodeName = null
             Jenkinsfile.instance = null
@@ -402,7 +418,7 @@ class JenkinsfileTest {
             Jenkinsfile.defaultNodeName = expectedName
 
             String actualName = Jenkinsfile.getNodeName()
-            assertEquals(expectedName, actualName)
+            assertThat(actualName, equalTo(expectedName))
         }
 
         @Test
@@ -412,7 +428,7 @@ class JenkinsfileTest {
             configureJenkins(env: [ DEFAULT_NODE_NAME: 'wrongName' ])
 
             String actualName = Jenkinsfile.getNodeName()
-            assertEquals(expectedName, actualName)
+            assertThat(actualName, equalTo(expectedName))
         }
 
         @Test
@@ -422,10 +438,11 @@ class JenkinsfileTest {
             configureJenkins(env: [ DEFAULT_NODE_NAME: expectedName ])
 
             String actualName = Jenkinsfile.getNodeName()
-            assertEquals(expectedName, actualName)
+            assertThat(actualName, equalTo(expectedName))
         }
     }
 
+    @Nested
     class ReadFile {
         @Test
         void returnsNullIfTheFileDoesNotExist() {
@@ -436,7 +453,7 @@ class JenkinsfileTest {
 
             def result = Jenkinsfile.readFile(filename)
 
-            assertEquals(null, result)
+            assertThat(result, equalTo(null))
         }
 
         @Test
@@ -451,7 +468,7 @@ class JenkinsfileTest {
 
             def result = Jenkinsfile.readFile(filename)
 
-            assertEquals(expectedContent, result)
+            assertThat(result, equalTo(expectedContent))
         }
     }
 

--- a/test/ParameterStoreBuildWrapperPluginTest.groovy
+++ b/test/ParameterStoreBuildWrapperPluginTest.groovy
@@ -1,7 +1,7 @@
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
 import static org.mockito.Mockito.spy;
@@ -12,15 +12,14 @@ import static org.mockito.Mockito.never
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.anyString
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class ParameterStoreBuildWrapperPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformValidateStage.resetPlugins()
             TerraformEnvironmentStage.reset()
@@ -43,12 +42,14 @@ class ParameterStoreBuildWrapperPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
-        @After
+        @AfterEach
         public void reset() {
             ParameterStoreBuildWrapperPlugin.reset()
         }
 
+        @Nested
         class WithTerraformValidateStage {
             @Test
             void doesNotDecorateTheTerraformValidateStageIfGlobalParametersNotSet() {
@@ -78,6 +79,7 @@ class ParameterStoreBuildWrapperPluginTest {
             }
         }
 
+        @Nested
         class WithTerraformEnvironmentStage {
             @Test
             void doesNotDecorateTheTerraformEnvironmentStageIfNoOptionsSet() {
@@ -135,8 +137,9 @@ class ParameterStoreBuildWrapperPluginTest {
         }
     }
 
+    @Nested
     class GetParameterOptions {
-        @After
+        @AfterEach
         public void reset() {
             ParameterStoreBuildWrapperPlugin.reset()
         }
@@ -152,7 +155,7 @@ class ParameterStoreBuildWrapperPluginTest {
 
             List actual = plugin.getParameterOptions(environment)
 
-            assertEquals(expected, actual)
+            assertThat(actual, equalTo(expected))
         }
 
         @Test
@@ -169,7 +172,7 @@ class ParameterStoreBuildWrapperPluginTest {
 
             List actual = plugin.getParameterOptions(environment)
 
-            assertEquals(expected, actual)
+            assertThat(actual, equalTo(expected))
         }
 
         @Test
@@ -187,12 +190,13 @@ class ParameterStoreBuildWrapperPluginTest {
 
             List actual = plugin.getParameterOptions(environment)
 
-            assertEquals(expected, actual)
+            assertThat(actual, equalTo(expected))
         }
     }
 
+    @Nested
     public class GetEnvironmentParameterOptions {
-        @After
+        @AfterEach
         public void reset() {
             Jenkinsfile.instance = null
             ParameterStoreBuildWrapperPlugin.reset()
@@ -215,7 +219,7 @@ class ParameterStoreBuildWrapperPluginTest {
 
             Map actual = plugin.getEnvironmentParameterOptions(environment)
 
-            assertEquals(expectedPath, actual.path)
+            assertThat(actual.path, equalTo(expectedPath))
         }
 
         @Test
@@ -229,12 +233,13 @@ class ParameterStoreBuildWrapperPluginTest {
 
             Map actual = plugin.getEnvironmentParameterOptions(environment)
 
-            assertEquals(expectedCredentialsId, actual.credentialsId.toString())
+            assertThat(actual.credentialsId.toString(), equalTo(expectedCredentialsId))
         }
     }
 
+    @Nested
     public class PathForEnvironment {
-        @After
+        @AfterEach
         public void reset() {
             Jenkinsfile.instance = null
             ParameterStoreBuildWrapperPlugin.reset()
@@ -258,7 +263,7 @@ class ParameterStoreBuildWrapperPluginTest {
             ParameterStoreBuildWrapperPlugin plugin = new ParameterStoreBuildWrapperPlugin()
 
             String actual = plugin.pathForEnvironment(environment)
-            assertEquals("/${organization}/${repoName}/${environment}/".toString(), actual)
+            assertThat(actual, equalTo("/${organization}/${repoName}/${environment}/".toString()))
         }
 
         @Test
@@ -273,12 +278,13 @@ class ParameterStoreBuildWrapperPluginTest {
             ParameterStoreBuildWrapperPlugin plugin = new ParameterStoreBuildWrapperPlugin()
 
             String actual = plugin.pathForEnvironment(environment)
-            assertEquals("/foo/${organization}/${environment}/${repoName}".toString(), actual)
+            assertThat(actual, equalTo("/foo/${organization}/${environment}/${repoName}".toString()))
         }
     }
 
+    @Nested
     class WithPathPattern {
-        @After
+        @AfterEach
         public void reset() {
             ParameterStoreBuildWrapperPlugin.reset()
         }
@@ -287,12 +293,13 @@ class ParameterStoreBuildWrapperPluginTest {
         void isFluent() {
             def result = ParameterStoreBuildWrapperPlugin.withPathPattern { options -> 'somePattern' }
 
-            assertEquals(ParameterStoreBuildWrapperPlugin.class, result)
+            assertThat(result, equalTo(ParameterStoreBuildWrapperPlugin.class))
         }
     }
 
+    @Nested
     class withGlobalParameter {
-        @After
+        @AfterEach
         public void reset() {
             ParameterStoreBuildWrapperPlugin.reset()
         }
@@ -302,7 +309,7 @@ class ParameterStoreBuildWrapperPluginTest {
             String path = '/path/'
             def result = ParameterStoreBuildWrapperPlugin.withGlobalParameter(path)
             println(result)
-            assertEquals([[path: '/path/']], result.globalParameterOptions)
+            assertThat(result.globalParameterOptions, equalTo([[path: '/path/']]))
         }
 
         @Test
@@ -313,7 +320,7 @@ class ParameterStoreBuildWrapperPluginTest {
 
             def result = ParameterStoreBuildWrapperPlugin.withGlobalParameter(path, options)
 
-            assertEquals(expected, result.globalParameterOptions)
+            assertThat(result.globalParameterOptions, equalTo(expected))
         }
 
         @Test
@@ -324,7 +331,7 @@ class ParameterStoreBuildWrapperPluginTest {
 
             def result = ParameterStoreBuildWrapperPlugin.withGlobalParameter(path, options)
 
-            assertEquals(expected, result.globalParameterOptions)
+            assertThat(result.globalParameterOptions, equalTo(expected))
         }
 
         @Test
@@ -338,7 +345,7 @@ class ParameterStoreBuildWrapperPluginTest {
             expected << [path:'/path2/']
             expected << [path: '/path3/', recursive: true]
             expected << [path: '/path4/', basename: 'something']
-            assertEquals(expected, result.globalParameterOptions)
+            assertThat(result.globalParameterOptions, equalTo(expected))
         }
     }
 }

--- a/test/ParameterStoreExecPluginTest.groovy
+++ b/test/ParameterStoreExecPluginTest.groovy
@@ -1,19 +1,17 @@
 import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class ParameterStoreExecPluginTest {
-    @After
+    @AfterEach
     public void reset() {
         Jenkinsfile.instance = null
         TerraformEnvironmentStage.reset()
@@ -28,6 +26,7 @@ class ParameterStoreExecPluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Init {
         @Test
         void modifiesTerraformEnvironmentStage() {
@@ -54,6 +53,7 @@ class ParameterStoreExecPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
         @Test
         void addsParameterStorePrefixToTerraformPlan() {
@@ -78,6 +78,7 @@ class ParameterStoreExecPluginTest {
         }
     }
 
+    @Nested
     public class PathForEnvironment {
         @Test
         void constructPathUsingOrgRepoAndEnvironment() {
@@ -89,7 +90,7 @@ class ParameterStoreExecPluginTest {
             ParameterStoreExecPlugin plugin = new ParameterStoreExecPlugin()
 
             String actual = plugin.pathForEnvironment(environment)
-            assertEquals(actual, "/${organization}/${repoName}/${environment}/".toString())
+            assertThat(actual, equalTo("/${organization}/${repoName}/${environment}/".toString()))
         }
     }
 

--- a/test/PassPlanFilePluginTest.groovy
+++ b/test/PassPlanFilePluginTest.groovy
@@ -1,8 +1,8 @@
 import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
@@ -10,15 +10,14 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
-import org.junit.Test
-import org.junit.Before
-import org.junit.After
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
 
-@RunWith(HierarchicalContextRunner.class)
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
 class PassPlanFilePluginTest {
-    @Before
+    @BeforeEach
     void resetJenkinsEnv() {
         Jenkinsfile.instance = mock(Jenkinsfile.class)
         when(Jenkinsfile.instance.getEnv()).thenReturn([:])
@@ -29,8 +28,9 @@ class PassPlanFilePluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformPlanCommand.resetPlugins()
             TerraformApplyCommand.resetPlugins()
@@ -63,6 +63,7 @@ class PassPlanFilePluginTest {
 
     }
 
+    @Nested
     public class Apply {
 
         @Test
@@ -97,6 +98,7 @@ class PassPlanFilePluginTest {
 
     }
 
+    @Nested
     public class StashPlan {
 
         @Test
@@ -109,11 +111,12 @@ class PassPlanFilePluginTest {
             stashClosure.delegate = new DummyJenkinsfile()
             stashClosure.call(passedClosure)
 
-            assertTrue(wasCalled)
+            assertThat(wasCalled, equalTo(true))
         }
 
     }
 
+    @Nested
     public class UnstashPlan {
 
         @Test
@@ -126,7 +129,7 @@ class PassPlanFilePluginTest {
             unstashClosure.delegate = new DummyJenkinsfile()
             unstashClosure.call(passedClosure)
 
-            assertTrue(wasCalled)
+            assertThat(wasCalled, equalTo(true))
         }
 
     }

--- a/test/PlanOnlyPluginTest.groovy
+++ b/test/PlanOnlyPluginTest.groovy
@@ -2,7 +2,7 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
@@ -10,15 +10,14 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
-import org.junit.Test
-import org.junit.Before
-import org.junit.After
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
 
-@RunWith(HierarchicalContextRunner.class)
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
 class PlanOnlyPluginTest {
-    @Before
+    @BeforeEach
     void resetJenkinsEnv() {
         Jenkinsfile.instance = mock(Jenkinsfile.class)
         when(Jenkinsfile.instance.getEnv()).thenReturn([:])
@@ -29,8 +28,9 @@ class PlanOnlyPluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformPlanCommand.resetPlugins()
             TerraformEnvironmentStage.reset()
@@ -60,6 +60,7 @@ class PlanOnlyPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
 
         @Test

--- a/test/RegressionStageTest.groovy
+++ b/test/RegressionStageTest.groovy
@@ -2,16 +2,15 @@ import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class RegressionStageTest {
 
+    @Nested
     public class AutomationRepo {
-        @After
+        @AfterEach
         void reset() {
             TerraformEnvironmentStage.reset()
             Jenkinsfile.instance = mock(Jenkinsfile.class)
@@ -78,8 +77,9 @@ class RegressionStageTest {
         }
     }
 
+    @Nested
     public class AddedPlugins {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformEnvironmentStage.reset()
         }

--- a/test/S3BackendPluginTest.groovy
+++ b/test/S3BackendPluginTest.groovy
@@ -3,19 +3,18 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.is
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class S3BackendPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformInitCommand.resetPlugins()
         }
@@ -29,8 +28,9 @@ class S3BackendPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
-        @After
+        @AfterEach
         void reset() {
             S3BackendPlugin.keyPattern = null
         }
@@ -120,6 +120,7 @@ class S3BackendPluginTest {
         }
     }
 
+    @Nested
     public class GetBackend {
         @Test
         void shouldReturnTheValueOfS3BackendBucket() {
@@ -168,6 +169,7 @@ class S3BackendPluginTest {
         }
     }
 
+    @Nested
     public class GetRegion {
         @Test
         void shouldReturnTheValueOfDefaultS3BackendRegion() {
@@ -242,8 +244,9 @@ class S3BackendPluginTest {
         }
     }
 
+    @Nested
     public class GetKey {
-        @After
+        @AfterEach
         void resetPlugins() {
             S3BackendPlugin.keyPattern = null
         }
@@ -269,6 +272,7 @@ class S3BackendPluginTest {
         }
     }
 
+    @Nested
     public class GetDynamoTable {
         @Test
         void shouldReturnDeprecatedS3BackendDynamoTableLockValue() {
@@ -343,6 +347,7 @@ class S3BackendPluginTest {
         }
     }
 
+    @Nested
     public class GetEncrypt {
         @Test
         void shouldReturnS3BackendEncryptValue() {
@@ -392,6 +397,7 @@ class S3BackendPluginTest {
         }
     }
 
+    @Nested
     public class GetKmsKeyId {
         @Test
         void shouldReturnS3BackendKmsKeyIdValue() {

--- a/test/SemanticVersionTest.groovy
+++ b/test/SemanticVersionTest.groovy
@@ -1,29 +1,22 @@
-import static org.junit.Assert.assertEquals
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.api.Test
 
-@RunWith(Parameterized.class)
 class SemanticVersionTest {
-
-    @Parameterized.Parameters
-    static data() {
-        Arrays.asList( new Object[100][])
-    }
-
-    SemanticVersionTest() { }
 
     @Test
     void sortsCorrectly() {
-        List<SemanticVersion> versions = SORTED.clone().collect { v -> new SemanticVersion(v) }
-        // Randomize
-        Collections.shuffle(versions)
-        // Then sort
-        versions.sort()
+        100.times {
+            List<SemanticVersion> versions = SORTED.clone().collect { v -> new SemanticVersion(v) }
+            // Randomize
+            Collections.shuffle(versions)
+            // Then sort
+            versions.sort()
 
-        def result = versions.collect { sv -> sv.version }
-        assertEquals(SORTED, result)
+            def result = versions.collect { sv -> sv.version }
+            assertThat(result, equalTo(SORTED))
+        }
     }
 
     static SORTED = [

--- a/test/StageDecorationsTest.groovy
+++ b/test/StageDecorationsTest.groovy
@@ -2,12 +2,11 @@ import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class StageDecorationsTest {
+    @Nested
     class WithoutGroup {
         @Test
         void applyEmptyDecorationsShouldRunInnerClosure() {
@@ -68,6 +67,7 @@ class StageDecorationsTest {
         }
     }
 
+    @Nested
     class WithGroup {
         @Test
         void applyEmptyDecorationsShouldRunInnerClosure() {
@@ -130,6 +130,7 @@ class StageDecorationsTest {
         }
     }
 
+    @Nested
     class WithAndWithoutGroups {
         @Test
         void applyWithoutGroupDoesNotRunGroupdDecorations() {

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -1,7 +1,7 @@
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertEquals
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -10,22 +10,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.anyMap;
 
-import org.junit.Test
-import org.junit.Before
-import org.junit.After
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TagPluginTest {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         TerraformApplyCommand.resetPlugins()
         TerraformPlanCommand.resetPlugins()
         TagPlugin.reset()
     }
 
+    @Nested
     public class Init {
         @Test
         void modifiesTerraformPlanCommand() {
@@ -44,42 +43,47 @@ class TagPluginTest {
         }
     }
 
+    @Nested
     class WithTag {
         @Test
         void isFluent() {
             def result = TagPlugin.withTag('key', 'value')
 
-            assertEquals(result, TagPlugin.class)
+            assertThat(result, equalTo(TagPlugin.class))
         }
     }
 
+    @Nested
     class WithTagFromFile {
         @Test
         void isFluent() {
             def result = TagPlugin.withTagFromFile('key', 'value')
 
-            assertEquals(result, TagPlugin.class)
+            assertThat(result, equalTo(TagPlugin.class))
         }
     }
 
+    @Nested
     class WithTagFromEnvironmentVariable {
         @Test
         void isFluent() {
             def result = TagPlugin.withTagFromEnvironmentVariable('key', 'variable')
 
-            assertEquals(result, TagPlugin.class)
+            assertThat(result, equalTo(TagPlugin.class))
         }
     }
 
+    @Nested
     class WithEnvironmentTag {
         @Test
         void isFluent() {
             def result = TagPlugin.withEnvironmentTag()
 
-            assertEquals(result, TagPlugin.class)
+            assertThat(result, equalTo(TagPlugin.class))
         }
     }
 
+    @Nested
     public class ApplyForPlanCommand {
         @Test
         public void addsTheTagArgument() {
@@ -94,6 +98,7 @@ class TagPluginTest {
             verify(command).withVariable(expectedVariableName, expectedTags)
         }
 
+        @Nested
         class WithVariableName {
             @Test
             void overridesTheDefaultVariableName() {
@@ -111,6 +116,7 @@ class TagPluginTest {
         }
     }
 
+    @Nested
     public class ApplyForApplyCommand {
         @Test
         public void addsTheTagArgument() {
@@ -136,6 +142,7 @@ class TagPluginTest {
             verify(command, times(0)).withVariable(anyString(), anyMap())
         }
 
+        @Nested
         class WithVariableName {
             @Test
             void overridesTheDefaultVariableName() {
@@ -153,8 +160,9 @@ class TagPluginTest {
         }
     }
 
+    @Nested
     public class GetTags {
-        @After
+        @AfterEach
         public void reset() {
             Jenkinsfile.reset()
         }
@@ -165,7 +173,7 @@ class TagPluginTest {
 
             def result = plugin.getTags()
 
-            assertEquals([:], result)
+            assertThat(result, equalTo([:]))
         }
 
         @Test
@@ -175,7 +183,7 @@ class TagPluginTest {
 
             def result = plugin.getTags()
 
-            assertEquals([mykey: 'myvalue'], result)
+            assertThat(result, equalTo([mykey: 'myvalue']))
         }
 
         @Test
@@ -186,7 +194,7 @@ class TagPluginTest {
 
             def result = plugin.getTags()
 
-            assertEquals([key1: 'value1', key2: 'value2'], result)
+            assertThat(result, equalTo([key1: 'value1', key2: 'value2']))
         }
 
         @Test
@@ -198,7 +206,7 @@ class TagPluginTest {
 
             def result = plugin.getTags(command)
 
-            assertEquals([ environment: 'myenv' ], result)
+            assertThat(result, equalTo([ environment: 'myenv' ]))
         }
 
         @Test
@@ -213,7 +221,7 @@ class TagPluginTest {
 
             Map expectedResult = [:]
             expectedResult[expectedTagKey] = 'myenv'
-            assertEquals(expectedResult, result)
+            assertThat(result, equalTo(expectedResult))
         }
 
         @Test
@@ -231,7 +239,7 @@ class TagPluginTest {
 
             def result = plugin.getTags(command)
 
-            assertEquals(['change-id': "${fileContent}".toString()], result)
+            assertThat(result, equalTo(['change-id': "${fileContent}".toString()]))
         }
 
         @Test
@@ -249,7 +257,7 @@ class TagPluginTest {
 
             def result = plugin.getTags(command)
 
-            assertEquals([ 'someTagName': expectedValue ], result)
+            assertThat(result, equalTo([ 'someTagName': expectedValue ]))
         }
 
         @Test
@@ -263,16 +271,17 @@ class TagPluginTest {
 
             def result = plugin.getTags(command)
 
-            assertEquals([key1: 'value1', environment: 'myenv', key2: 'value2'], result)
+            assertThat(result, equalTo([key1: 'value1', environment: 'myenv', key2: 'value2']))
         }
     }
 
+    @Nested
     class DisableOnApply {
         @Test
         void isFluent() {
             def result = TagPlugin.disableOnApply()
 
-            assertEquals(result, TagPlugin.class)
+            assertThat(result, equalTo(TagPlugin.class))
         }
     }
 }

--- a/test/TargetPluginTest.groovy
+++ b/test/TargetPluginTest.groovy
@@ -2,19 +2,17 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test
-import org.junit.Before
-import org.junit.After
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TargetPluginTest {
-    @Before
+    @BeforeEach
     void resetJenkinsEnv() {
         Jenkinsfile.instance = mock(Jenkinsfile.class)
         when(Jenkinsfile.instance.getEnv()).thenReturn([:])
@@ -25,8 +23,9 @@ class TargetPluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformPlanCommand.resetPlugins()
             TerraformApplyCommand.resetPlugins()
@@ -64,6 +63,7 @@ class TargetPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
         @Test
         void addsTargetArgumentToTerraformPlan() {

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -1,22 +1,21 @@
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.startsWith
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformApplyCommandTest {
+    @Nested
     public class WithInput {
         @Test
         void defaultsToFalse() {
@@ -43,6 +42,7 @@ class TerraformApplyCommandTest {
         }
     }
 
+    @Nested
     public class WithArgument {
         @Test
         void addsArgument() {
@@ -62,6 +62,7 @@ class TerraformApplyCommandTest {
         }
     }
 
+    @Nested
     public class WithVariableString {
         @Test
         void addsArgument() {
@@ -83,7 +84,8 @@ class TerraformApplyCommandTest {
             assertThat(actualCommand, containsString("-var 'key2=val2'"))
         }
 
-        class WithVariablePattern {
+        @Nested
+        public class WithVariablePattern {
             @Test
             void usesTheNewPattern() {
                 def command = new TerraformApplyCommand().withVariablePattern { key, value -> "boop-${key}-${value}-boop" }
@@ -95,6 +97,7 @@ class TerraformApplyCommandTest {
         }
     }
 
+    @Nested
     public class WithVariableMap {
         @Test
         void convertsMapToStringAndTreatsLikeAStringVariable() {
@@ -109,6 +112,7 @@ class TerraformApplyCommandTest {
         }
     }
 
+    @Nested
     public class ConvertMapToCliString {
         @Test
         void handlesSingleKeyPair() {
@@ -116,7 +120,7 @@ class TerraformApplyCommandTest {
             def command = new TerraformApplyCommand()
 
             def result = command.convertMapToCliString(map)
-            assertEquals('{mapKey=\"mapValue\"}', result)
+            assertThat(result, equalTo('{mapKey=\"mapValue\"}'))
         }
 
         @Test
@@ -125,7 +129,7 @@ class TerraformApplyCommandTest {
             def command = new TerraformApplyCommand()
 
             def result = command.convertMapToCliString(map)
-            assertEquals('{mapKey1=\"mapValue1\",mapKey2=\"mapValue2\"}', result)
+            assertThat(result, equalTo('{mapKey1=\"mapValue1\",mapKey2=\"mapValue2\"}'))
         }
 
         @Test
@@ -137,10 +141,11 @@ class TerraformApplyCommandTest {
             def map = [mapKey1: 'mapValue1', mapKey2: 'mapValue2']
 
             def result = command.convertMapToCliString(map)
-            assertEquals('[mapValue1|mapKey1;mapValue2|mapKey2]', result)
+            assertThat(result, equalTo('[mapValue1|mapKey1;mapValue2|mapKey2]'))
         }
     }
 
+    @Nested
     public class WithDirectory {
         @Test
         void addsDirectoryArgument() {
@@ -151,6 +156,7 @@ class TerraformApplyCommandTest {
         }
     }
 
+    @Nested
     public class WithPrefix {
         @Test
         void addsPrefixToBeginningOfCommand() {
@@ -170,6 +176,7 @@ class TerraformApplyCommandTest {
         }
     }
 
+    @Nested
     public class WithSuffix {
         @Test
         void addsSuffixToEndOfCommand() {
@@ -199,8 +206,9 @@ class TerraformApplyCommandTest {
         }
     }
 
+    @Nested
     public class Plugins {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformApplyCommand.resetPlugins()
         }

--- a/test/TerraformDirectoryPluginTest.groovy
+++ b/test/TerraformDirectoryPluginTest.groovy
@@ -1,17 +1,16 @@
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformDirectoryPluginTest {
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformInitCommand.resetPlugins()
             TerraformValidateCommand.resetPlugins()
@@ -52,12 +51,14 @@ class TerraformDirectoryPluginTest {
         }
     }
 
+    @Nested
     public class Apply {
-        @After
+        @AfterEach
         void resetJenkinsEnv() {
             TerraformDirectoryPlugin.withDirectory("./terraform/")
         }
 
+        @Nested
         public class WithDirectoryProvided {
             @Test
             void addsDirectoryToTerraformInit() {
@@ -108,6 +109,7 @@ class TerraformDirectoryPluginTest {
             }
         }
 
+        @Nested
         public class WithoutDirectoryProvided {
             @Test
             void addsDirectoryToTerraformInit() {

--- a/test/TerraformEnvironmentStageShellHookPluginTest.groovy
+++ b/test/TerraformEnvironmentStageShellHookPluginTest.groovy
@@ -1,10 +1,8 @@
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.jupiter.api.Assertions.assertNull
 import static org.mockito.Mockito.inOrder
 import static org.mockito.Mockito.when
 import static org.mockito.Mockito.mock
@@ -22,16 +20,15 @@ import static TerraformEnvironmentStage.APPLY
 import static TerraformEnvironmentStage.APPLY_COMMAND
 
 import org.mockito.InOrder
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
 
-@RunWith(HierarchicalContextRunner.class)
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
 class TerraformEnvironmentStageShellHookPluginTest {
     def hookKeys = [ALL, INIT_COMMAND, PLAN, PLAN_COMMAND, APPLY, APPLY_COMMAND]
 
-    @After
+    @AfterEach
     public void reset() {
         Jenkinsfile.instance = null
         TerraformEnvironmentStage.reset()
@@ -45,20 +42,22 @@ class TerraformEnvironmentStageShellHookPluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Hooks {
         @Test
         void hasAllHooksUnconfigured() {
             TerraformEnvironmentStageShellHookPlugin.reset()
             def hooks = TerraformEnvironmentStageShellHookPlugin.hooks
-            assertEquals(hooks.size(), 6)
+            assertThat(hooks.size(), equalTo(6))
             hookKeys.each {
                 assertThat(hooks[it], instanceOf(HookPoint))
-                assertFalse(hooks[it].isConfigured())
-                assertEquals(hooks[it].getName(), it)
+                assertThat(hooks[it].isConfigured(), equalTo(false))
+                assertThat(it, equalTo(hooks[it].getName()))
             }
         }
     }
 
+    @Nested
     public class Init {
         @Test
         void modifiesTerraformEnvironmentStage() {
@@ -69,6 +68,7 @@ class TerraformEnvironmentStageShellHookPluginTest {
         }
     }
 
+    @Nested
     public class WithHook {
         @Test
         void setDefaultOnSuccess() {
@@ -76,13 +76,13 @@ class TerraformEnvironmentStageShellHookPluginTest {
             def hooks = TerraformEnvironmentStageShellHookPlugin.hooks
             hookKeys.each {
                 if (it == APPLY) {
-                    assertTrue(hooks[it].isConfigured())
-                    assertEquals(hooks[it].runAfterOnSuccess, 'foo bar')
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
+                    assertThat(hooks[it].runAfterOnSuccess, equalTo('foo bar'))
                     assertNull(hooks[it].runBefore)
                     assertNull(hooks[it].runAfterAlways)
                     assertNull(hooks[it].runAfterOnFailure)
                 } else {
-                    assertFalse(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(false))
                 }
             }
         }
@@ -93,13 +93,13 @@ class TerraformEnvironmentStageShellHookPluginTest {
             def hooks = TerraformEnvironmentStageShellHookPlugin.hooks
             hookKeys.each {
                 if (it == PLAN_COMMAND) {
-                    assertTrue(hooks[it].isConfigured())
-                    assertEquals(hooks[it].runBefore, 'foo bar')
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
+                    assertThat(hooks[it].runBefore, equalTo('foo bar'))
                     assertNull(hooks[it].runAfterAlways)
                     assertNull(hooks[it].runAfterOnFailure)
                     assertNull(hooks[it].runAfterOnSuccess)
                 } else {
-                    assertFalse(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(false))
                 }
             }
         }
@@ -110,13 +110,13 @@ class TerraformEnvironmentStageShellHookPluginTest {
             def hooks = TerraformEnvironmentStageShellHookPlugin.hooks
             hookKeys.each {
                 if (it == PLAN) {
-                    assertTrue(hooks[it].isConfigured())
-                    assertEquals(hooks[it].runAfterOnFailure, 'foo bar')
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
+                    assertThat(hooks[it].runAfterOnFailure, equalTo('foo bar'))
                     assertNull(hooks[it].runBefore)
                     assertNull(hooks[it].runAfterAlways)
                     assertNull(hooks[it].runAfterOnSuccess)
                 } else {
-                    assertFalse(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(false))
                 }
             }
         }
@@ -127,13 +127,13 @@ class TerraformEnvironmentStageShellHookPluginTest {
             def hooks = TerraformEnvironmentStageShellHookPlugin.hooks
             hookKeys.each {
                 if (it == PLAN) {
-                    assertTrue(hooks[it].isConfigured())
-                    assertEquals(hooks[it].runAfterAlways, 'foo bar')
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
+                    assertThat(hooks[it].runAfterAlways, equalTo('foo bar'))
                     assertNull(hooks[it].runBefore)
                     assertNull(hooks[it].runAfterOnFailure)
                     assertNull(hooks[it].runAfterOnSuccess)
                 } else {
-                    assertFalse(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(false))
                 }
             }
         }
@@ -145,13 +145,13 @@ class TerraformEnvironmentStageShellHookPluginTest {
             def hooks = TerraformEnvironmentStageShellHookPlugin.hooks
             hookKeys.each {
                 if (it == PLAN) {
-                    assertTrue(hooks[it].isConfigured())
-                    assertEquals(hooks[it].runAfterAlways, 'baz')
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
+                    assertThat(hooks[it].runAfterAlways, equalTo('baz'))
                     assertNull(hooks[it].runBefore)
                     assertNull(hooks[it].runAfterOnFailure)
                     assertNull(hooks[it].runAfterOnSuccess)
                 } else {
-                    assertFalse(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(false))
                 }
             }
         }
@@ -165,30 +165,31 @@ class TerraformEnvironmentStageShellHookPluginTest {
             def hooks = TerraformEnvironmentStageShellHookPlugin.hooks
             hookKeys.each {
                 if (it == ALL) {
-                    assertTrue(hooks[it].isConfigured())
-                    assertEquals(hooks[it].runBefore, 'all-before')
-                    assertEquals(hooks[it].runAfterAlways, 'all-after-always')
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
+                    assertThat(hooks[it].runBefore, equalTo('all-before'))
+                    assertThat(hooks[it].runAfterAlways, equalTo('all-after-always'))
                     assertNull(hooks[it].runAfterOnFailure)
                     assertNull(hooks[it].runAfterOnSuccess)
                 } else if (it == INIT_COMMAND) {
-                    assertTrue(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
                     assertNull(hooks[it].runBefore)
                     assertNull(hooks[it].runAfterAlways)
                     assertNull(hooks[it].runAfterOnFailure)
-                    assertEquals(hooks[it].runAfterOnSuccess, 'init-command-after-success')
+                    assertThat(hooks[it].runAfterOnSuccess, equalTo('init-command-after-success'))
                 } else if (it == PLAN) {
-                    assertTrue(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(true))
                     assertNull(hooks[it].runBefore)
                     assertNull(hooks[it].runAfterAlways)
                     assertNull(hooks[it].runAfterOnFailure)
-                    assertEquals(hooks[it].runAfterOnSuccess, 'plan-after-success')
+                    assertThat(hooks[it].runAfterOnSuccess, equalTo('plan-after-success'))
                 } else {
-                    assertFalse(hooks[it].isConfigured())
+                    assertThat(hooks[it].isConfigured(), equalTo(false))
                 }
             }
         }
     }
 
+    @Nested
     public class Apply {
         @Test
         void testApply() {

--- a/test/TerraformEnvironmentStageTest.groovy
+++ b/test/TerraformEnvironmentStageTest.groovy
@@ -2,27 +2,25 @@ import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
+import static org.hamcrest.CoreMatchers.is
+import static org.hamcrest.CoreMatchers.instanceOf
 import static org.hamcrest.Matchers.hasItem
-import static org.hamcrest.Matchers.is
-import static org.hamcrest.Matchers.isA
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.MatcherAssert.assertThat
 import static TerraformEnvironmentStage.PLAN
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformEnvironmentStageTest {
-    @After
+    @AfterEach
     void resetPlugins() {
         TerraformEnvironmentStage.reset()
     }
 
+    @Nested
     public class ToString {
         @Test
         void returnsEnvironmentName() {
@@ -31,10 +29,11 @@ class TerraformEnvironmentStageTest {
 
             def result = stage.toString()
 
-            assertEquals(expectedEnvironment, result)
+            assertThat(result, equalTo(expectedEnvironment))
         }
     }
 
+    @Nested
     public class Then {
 
         @Test
@@ -44,10 +43,11 @@ class TerraformEnvironmentStageTest {
 
             def result = stage.then(stage2)
 
-            assertThat(result, isA(BuildGraph.class))
+            assertThat(result, instanceOf(BuildGraph.class))
         }
     }
 
+    @Nested
     public class AddedPlugins {
         @Test
         void willHaveApplyCalled() {
@@ -61,6 +61,7 @@ class TerraformEnvironmentStageTest {
         }
     }
 
+    @Nested
     public class WithEnv {
         @Test
         void addsAnInstanceOfEnvironmentVariablePlugin() {
@@ -69,7 +70,7 @@ class TerraformEnvironmentStageTest {
 
             def plugins = stage.getAllPlugins()
 
-            assertThat(plugins, hasItem(isA(EnvironmentVariablePlugin.class)))
+            assertThat(plugins, hasItem(instanceOf(EnvironmentVariablePlugin.class)))
         }
 
         @Test
@@ -87,7 +88,7 @@ class TerraformEnvironmentStageTest {
             def plugin1Index = plugins.findIndexOf { it == plugin1 }
 
             assertThat(plugins[plugin1Index], is(plugin1))
-            assertThat(plugins[plugin1Index + 1], isA(EnvironmentVariablePlugin.class))
+            assertThat(plugins[plugin1Index + 1], is(instanceOf(EnvironmentVariablePlugin.class)))
             assertThat(plugins[plugin1Index + 2], is(plugin3))
         }
 
@@ -101,7 +102,7 @@ class TerraformEnvironmentStageTest {
             def plugins = stage.getAllPlugins()
                                .findAll { plugin -> plugin instanceof EnvironmentVariablePlugin }
 
-            assertEquals(2, plugins.size())
+            assertThat(plugins.size(), equalTo(2))
         }
 
         @Test
@@ -115,7 +116,7 @@ class TerraformEnvironmentStageTest {
 
             def pluginsAfter = unmodifiedStage.getAllPlugins()
 
-            assertEquals(pluginsBefore, pluginsAfter)
+            assertThat(pluginsAfter, equalTo(pluginsBefore))
         }
 
         @Test
@@ -123,10 +124,11 @@ class TerraformEnvironmentStageTest {
             def stage = new TerraformEnvironmentStage('foo')
             def result = stage.withEnv('somekey', 'somevalue')
 
-            assertTrue(result == stage)
+            assertThat(result, equalTo(stage))
         }
     }
 
+    @Nested
     public class WithGlobalEnv {
         @Test
         void addsAnInstanceOfEnvironmeentVariablePlugin() {
@@ -134,24 +136,25 @@ class TerraformEnvironmentStageTest {
 
             def plugins = TerraformEnvironmentStage.getPlugins()
 
-            assertThat(plugins, hasItem(isA(EnvironmentVariablePlugin.class)))
+            assertThat(plugins, hasItem(is(instanceOf(EnvironmentVariablePlugin.class))))
         }
 
         @Test
         void isFluent() {
             def result = TerraformEnvironmentStage.withGlobalEnv('somekey', 'somevalue')
 
-            assertTrue(result == TerraformEnvironmentStage.class)
+            assertThat(result, equalTo(TerraformEnvironmentStage.class))
         }
     }
 
+    @Nested
     class PipelineConfigurations {
-        @Before
+        @BeforeEach
         void resetBefore() {
             Jenkinsfile.reset()
         }
 
-        @After
+        @AfterEach
         void resetAfter() {
             Jenkinsfile.reset()
         }
@@ -162,7 +165,7 @@ class TerraformEnvironmentStageTest {
 
             def result = stage.pipelineConfiguration()
 
-            assertThat(result, isA(Closure.class))
+            assertThat(result, is(instanceOf(Closure.class)))
         }
 
         @Test
@@ -178,9 +181,10 @@ class TerraformEnvironmentStageTest {
         }
     }
 
+    @Nested
     class WithStageNamePattern {
-        @Before
-        @After
+        @BeforeEach
+        @AfterEach
         void reset() {
             TerraformEnvironmentStage.reset()
         }
@@ -191,7 +195,7 @@ class TerraformEnvironmentStageTest {
 
             def actualName = stage.getStageNameFor(PLAN)
 
-            assertEquals('plan-myenv', actualName)
+            assertThat(actualName, equalTo('plan-myenv'))
         }
 
         @Test
@@ -201,7 +205,7 @@ class TerraformEnvironmentStageTest {
 
             def actualName = stage.getStageNameFor(PLAN)
 
-            assertEquals('plan-override-myenv', actualName)
+            assertThat(actualName, equalTo('plan-override-myenv'))
         }
     }
 }

--- a/test/TerraformFormatCommandTest.groovy
+++ b/test/TerraformFormatCommandTest.groovy
@@ -1,23 +1,22 @@
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.startsWith
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformFormatCommandTest {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         TerraformFormatCommand.reset()
     }
 
+    @Nested
     public class ToString {
         @Test
         void includesTerraformFormatCommand() {
@@ -28,6 +27,7 @@ class TerraformFormatCommandTest {
             assertThat(actual, startsWith('terraform fmt'))
         }
 
+        @Nested
         public class WithCheck {
             @Test
             void addsCheckOptionByDefault() {
@@ -49,6 +49,7 @@ class TerraformFormatCommandTest {
                 assertThat(actual, not(containsString('-check')))
             }
 
+            @Nested
             public class WithPatternOverride {
                 @Test
                 void usesThePatternWhenCheckIsFalse() {
@@ -74,6 +75,7 @@ class TerraformFormatCommandTest {
             }
         }
 
+        @Nested
         public class WithRecursive {
             @Test
             void doesNothingByDefaultUnsupportedByTerraformm11() {
@@ -82,9 +84,10 @@ class TerraformFormatCommandTest {
                 TerraformFormatCommand.withRecursive()
                 def actual = command.toString()
 
-                assertEquals(actual, 'terraform fmt')
+                assertThat(actual, equalTo('terraform fmt'))
             }
 
+            @Nested
             public class WithPatternOverride {
                 @Test
                 void usesThePatternWhenCheckIsFalse() {
@@ -110,6 +113,7 @@ class TerraformFormatCommandTest {
             }
         }
 
+        @Nested
         public class WithDiff {
             @Test
             void addsDiffOptionByDefault() {
@@ -131,6 +135,7 @@ class TerraformFormatCommandTest {
                 assertThat(actual, not(containsString('-diff')))
             }
 
+            @Nested
             public class WithPatternOverride {
                 @Test
                 void usesThePatternWhenCheckIsFalse() {
@@ -157,60 +162,66 @@ class TerraformFormatCommandTest {
         }
     }
 
+    @Nested
     public class WithCheck {
         @Test
         void isFluent() {
             def result = TerraformFormatCommand.withCheck()
 
-            assertEquals(TerraformFormatCommand.class, result)
+            assertThat(result, equalTo(TerraformFormatCommand.class))
         }
     }
 
+    @Nested
     public class WithRecursive {
         @Test
         void isFluent() {
             def result = TerraformFormatCommand.withRecursive()
 
-            assertEquals(TerraformFormatCommand.class, result)
+            assertThat(result, equalTo(TerraformFormatCommand.class))
         }
     }
 
+    @Nested
     public class WithDiff {
         @Test
         void isFluent() {
             def result = TerraformFormatCommand.withDiff()
 
-            assertEquals(TerraformFormatCommand.class, result)
+            assertThat(result, equalTo(TerraformFormatCommand.class))
         }
     }
 
+    @Nested
     public class WithCheckOptionPattern {
         @Test
         void isFluent() {
             def command = new TerraformFormatCommand()
             def result = command.withCheckOptionPattern { "somevalue" }
 
-            assertEquals(command, result)
+            assertThat(result, equalTo(command))
         }
     }
 
+    @Nested
     public class WithRecursiveOptionPattern {
         @Test
         void isFluent() {
             def command = new TerraformFormatCommand()
             def result = command.withRecursiveOptionPattern { 'somevalue' }
 
-            assertEquals(command, result)
+            assertThat(result, equalTo(command))
         }
     }
 
+    @Nested
     public class WithDiffOptionPattern {
         @Test
         void isFluent() {
             def command = new TerraformFormatCommand()
             def result = command.withDiffOptionPattern { 'somevalue' }
 
-            assertEquals(command, result)
+            assertThat(result, equalTo(command))
         }
     }
 }

--- a/test/TerraformInitCommandTest.groovy
+++ b/test/TerraformInitCommandTest.groovy
@@ -2,18 +2,17 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.startsWith
 import static org.hamcrest.Matchers.endsWith
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformInitCommandTest {
+    @Nested
     public class WithInput {
         @Test
         void defaultsToFalse() {
@@ -40,6 +39,7 @@ class TerraformInitCommandTest {
         }
     }
 
+    @Nested
     public class WithBackendConfig {
         @Test
         void notPresentByDefault() {
@@ -80,6 +80,7 @@ class TerraformInitCommandTest {
         }
     }
 
+    @Nested
     public class WithDirectory {
         @Test
         void addsDirectoryArgument() {
@@ -90,6 +91,7 @@ class TerraformInitCommandTest {
         }
     }
 
+    @Nested
     public class WithPrefix {
         @Test
         void addsPrefixToBeginningOfCommand() {
@@ -109,6 +111,7 @@ class TerraformInitCommandTest {
         }
     }
 
+    @Nested
     public class WithSuffix {
         @Test
         void addsSuffixToEndOfCommand() {
@@ -128,8 +131,9 @@ class TerraformInitCommandTest {
         }
     }
 
+    @Nested
     public class Plugins {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformInitCommand.resetPlugins()
         }

--- a/test/TerraformLandscapePluginTest.groovy
+++ b/test/TerraformLandscapePluginTest.groovy
@@ -1,24 +1,23 @@
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test
-import org.junit.After
-import org.junit.Before
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformLandscapePluginTest {
-    @Before
+    @BeforeEach
     public void resetJenkinsEnv() {
         Jenkinsfile.instance = mock(Jenkinsfile.class)
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformPlanCommand.resetPlugins()
         }
@@ -32,8 +31,8 @@ class TerraformLandscapePluginTest {
         }
     }
 
+    @Nested
     public class Apply {
-
         @Test
         void addsLandscapeArgumentToTerraformPlan() {
             TerraformLandscapePlugin plugin = new TerraformLandscapePlugin()

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -1,23 +1,21 @@
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.startsWith
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformPlanCommandTest {
+    @Nested
     public class WithInput {
         @Test
         void defaultsToFalse() {
@@ -44,6 +42,7 @@ class TerraformPlanCommandTest {
         }
     }
 
+    @Nested
     public class WithDirectory {
         @Test
         void addsDirectoryArgument() {
@@ -54,6 +53,7 @@ class TerraformPlanCommandTest {
         }
     }
 
+    @Nested
     public class WithPrefix {
         @Test
         void addsPrefixToBeginningOfCommand() {
@@ -73,6 +73,7 @@ class TerraformPlanCommandTest {
         }
     }
 
+    @Nested
     public class WithSuffix {
         @Test
         void addsSuffixToEndOfCommand() {
@@ -102,6 +103,7 @@ class TerraformPlanCommandTest {
         }
     }
 
+    @Nested
     public class WithArgument {
         @Test
         void addsArgument() {
@@ -121,6 +123,7 @@ class TerraformPlanCommandTest {
         }
     }
 
+    @Nested
     public class WithVariableString {
         @Test
         void addsArgument() {
@@ -154,6 +157,7 @@ class TerraformPlanCommandTest {
         }
     }
 
+    @Nested
     public class WithVariableMap {
         @Test
         void convertsMapToStringAndTreatsLikeAStringVariable() {
@@ -168,6 +172,7 @@ class TerraformPlanCommandTest {
         }
     }
 
+    @Nested
     public class ConvertMapToCliString {
         @Test
         void handlesSingleKeyPair() {
@@ -175,7 +180,7 @@ class TerraformPlanCommandTest {
             def command = new TerraformPlanCommand()
 
             def result = command.convertMapToCliString(map)
-            assertEquals('{mapKey=\"mapValue\"}', result)
+            assertThat(result, equalTo('{mapKey=\"mapValue\"}'))
         }
 
         @Test
@@ -184,7 +189,7 @@ class TerraformPlanCommandTest {
             def command = new TerraformPlanCommand()
 
             def result = command.convertMapToCliString(map)
-            assertEquals('{mapKey1=\"mapValue1\",mapKey2=\"mapValue2\"}', result)
+            assertThat(result, equalTo('{mapKey1=\"mapValue1\",mapKey2=\"mapValue2\"}'))
         }
 
         @Test
@@ -196,10 +201,11 @@ class TerraformPlanCommandTest {
             def map = [mapKey1: 'mapValue1', mapKey2: 'mapValue2']
 
             def result = command.convertMapToCliString(map)
-            assertEquals('[mapValue1|mapKey1;mapValue2|mapKey2]', result)
+            assertThat(result, equalTo('[mapValue1|mapKey1;mapValue2|mapKey2]'))
         }
     }
 
+    @Nested
     public class WithStandardErrorRedirection {
         @Test
         void sendsStandardErrorToTheGivenFile() {
@@ -226,12 +232,13 @@ class TerraformPlanCommandTest {
             def expectedCommand = new TerraformPlanCommand()
             def actualCommand = expectedCommand.withStandardErrorRedirection('error.txt')
 
-            assertTrue(expectedCommand == actualCommand)
+            assertThat(expectedCommand, equalTo(actualCommand))
         }
     }
 
+    @Nested
     public class Plugins {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformPlanCommand.resetPlugins()
         }

--- a/test/TerraformPluginTest.groovy
+++ b/test/TerraformPluginTest.groovy
@@ -1,24 +1,23 @@
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformPluginTest {
 
+    @Nested
     class VersionDetection {
-        @Before
-        @After
+        @BeforeEach
+        @AfterEach
         void reset() {
             TerraformPlugin.reset()
             Jenkinsfile.reset()
@@ -32,7 +31,7 @@ class TerraformPluginTest {
 
             def foundVersion = plugin.detectVersion()
 
-            assertEquals(expectedVersion, foundVersion)
+            assertThat(expectedVersion, equalTo(foundVersion))
         }
 
         @Test
@@ -46,7 +45,7 @@ class TerraformPluginTest {
 
             def foundVersion = plugin.detectVersion()
 
-            assertEquals(expectedVersion, foundVersion)
+            assertThat(expectedVersion, equalTo(foundVersion))
         }
 
         @Test
@@ -60,7 +59,7 @@ class TerraformPluginTest {
 
             def foundVersion = plugin.detectVersion()
 
-            assertEquals(expectedVersion, foundVersion)
+            assertThat(expectedVersion, equalTo(foundVersion))
         }
 
         @Test
@@ -72,13 +71,14 @@ class TerraformPluginTest {
 
             def foundVersion = plugin.detectVersion()
 
-            assertEquals(TerraformPlugin.DEFAULT_VERSION, foundVersion)
+            assertThat(TerraformPlugin.DEFAULT_VERSION, equalTo(foundVersion))
         }
     }
 
+    @Nested
     class CheckVersion {
-        @Before
-        @After
+        @BeforeEach
+        @AfterEach
         void reset() {
             TerraformPlugin.reset()
             Jenkinsfile.reset()
@@ -92,8 +92,9 @@ class TerraformPluginTest {
         }
     }
 
+    @Nested
     class WithVersion {
-        @After
+        @AfterEach
         void reset() {
             TerraformPlugin.reset()
         }
@@ -101,12 +102,13 @@ class TerraformPluginTest {
         @Test
         void usesVersionEvenIfFileExists() {
             TerraformPlugin.withVersion('2.0.0')
-            assertEquals('2.0.0', TerraformPlugin.version)
+            assertThat('2.0.0', equalTo(TerraformPlugin.version))
         }
     }
 
+    @Nested
     class Strategyfor {
-        @After
+        @AfterEach
         void reset() {
             TerraformPlugin.reset()
         }
@@ -140,6 +142,7 @@ class TerraformPluginTest {
 
     }
 
+    @Nested
     class ApplyTerraformValidateCommand {
         @Test
         void shouldApplyTheCorrectStrategyToTerraformValidateCommand() {
@@ -155,6 +158,7 @@ class TerraformPluginTest {
         }
     }
 
+    @Nested
     class ApplyTerraformFormatCommand {
         @Test
         void shouldApplyTheCorrectStrategyToTerraformFormatCommand() {
@@ -170,6 +174,7 @@ class TerraformPluginTest {
         }
     }
 
+    @Nested
     class ApplyTerraformPlanCommand {
         @Test
         void shouldApplyTheCorrectStrategyToTerraformPlanCommand() {
@@ -185,6 +190,7 @@ class TerraformPluginTest {
         }
     }
 
+    @Nested
     class ApplyTerraformApplyCommand {
         @Test
         void shouldApplyTheCorrectStrategyToTerraformApplyCommand() {
@@ -200,6 +206,7 @@ class TerraformPluginTest {
         }
     }
 
+    @Nested
     class ApplyTerraformValidateStage {
         @Test
         void shouldDecorateTheGivenStage() {
@@ -214,6 +221,7 @@ class TerraformPluginTest {
         }
     }
 
+    @Nested
     class ModifyTerraformValidateStage {
         @Test
         void shouldApplyTheCorrectStrategyToTerraformValidateStage() {

--- a/test/TerraformPluginVersion11Test.groovy
+++ b/test/TerraformPluginVersion11Test.groovy
@@ -1,22 +1,21 @@
 import static org.hamcrest.Matchers.containsString
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify;
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformPluginVersion11Test {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     void reset() {
         TerraformPlugin.reset()
     }
 
+    @Nested
     class ModifiesTerraformValidateCommand {
         @Test
         void addsCheckVariablesFalseToValidateCommand() {
@@ -29,6 +28,7 @@ class TerraformPluginVersion11Test {
         }
     }
 
+    @Nested
     class ModifiesTerraformPlanCommand {
         @Test
         void toPreserveTerraform11CliSyntaxForVariables() {
@@ -55,6 +55,7 @@ class TerraformPluginVersion11Test {
         }
     }
 
+    @Nested
     class ModifiesTerraformApplyCommand {
         @Test
         void toPreserveTerraform11CliSyntaxForVariables() {

--- a/test/TerraformPluginVersion12Test.groovy
+++ b/test/TerraformPluginVersion12Test.groovy
@@ -1,27 +1,26 @@
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.endsWith
+import static org.hamcrest.Matchers.is
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Matchers.any
 import static org.mockito.Matchers.eq
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify;
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformPluginVersion12Test {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     void reset() {
         TerraformFormatCommand.reset()
     }
 
+    @Nested
     class AddInitBefore {
         @Test
         void runsTheInnerClosure() {
@@ -33,10 +32,11 @@ class TerraformPluginVersion12Test {
             beforeClosure.delegate = new DummyJenkinsfile()
             beforeClosure(innerClosure)
 
-            assertTrue(wasRun)
+            assertThat(wasRun, is(true))
         }
     }
 
+    @Nested
     class InitCommandForValidate {
         @Test
         void createsCommandWithNoBackend() {
@@ -46,6 +46,7 @@ class TerraformPluginVersion12Test {
         }
     }
 
+    @Nested
     class ModifiesTerraformValidateStage {
         @Test
         void addsTerraformInitBeforeValidate()  {
@@ -58,6 +59,7 @@ class TerraformPluginVersion12Test {
         }
     }
 
+    @Nested
     class ModifiesTerraformPlanCommand {
         @Test
         void toUseTerraform12CliSyntaxForVariables() {
@@ -84,6 +86,7 @@ class TerraformPluginVersion12Test {
         }
     }
 
+    @Nested
     class ModifiesTerraformApplyCommand {
         @Test
         void toUseTerraform12CliSyntaxForVariables() {
@@ -110,7 +113,9 @@ class TerraformPluginVersion12Test {
         }
     }
 
+    @Nested
     class ModifiesTerraformFormatCommand {
+        @Nested
         class WithCheck {
             @Test
             void usesCheckFlagWhenCheckIsEnabled() {
@@ -137,6 +142,7 @@ class TerraformPluginVersion12Test {
             }
         }
 
+        @Nested
         class WithRecursive {
             @Test
             void usesRecursiveFlagWhenRecursiveIsEnabled() {
@@ -163,6 +169,7 @@ class TerraformPluginVersion12Test {
             }
         }
 
+        @Nested
         class WithDiff {
             @Test
             void usesDiffFlagWhenDiffIsEnabled() {

--- a/test/TerraformValidateCommandTest.groovy
+++ b/test/TerraformValidateCommandTest.groovy
@@ -1,24 +1,23 @@
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.endsWith
 import static org.hamcrest.Matchers.startsWith
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformValidateCommandTest {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         TerraformValidateCommand.resetPlugins()
     }
 
+    @Nested
     public class WithDirectory {
         @Test
         void addsDirectoryArgument() {
@@ -29,6 +28,7 @@ class TerraformValidateCommandTest {
         }
     }
 
+    @Nested
     public class WithPrefix {
         @Test
         void addsPrefixToBeginningOfCommand() {
@@ -48,6 +48,7 @@ class TerraformValidateCommandTest {
         }
     }
 
+    @Nested
     public class WithSuffix {
         @Test
         void addsSuffixToEndOfCommand() {
@@ -77,8 +78,9 @@ class TerraformValidateCommandTest {
         }
     }
 
+    @Nested
     public class Plugins {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformValidateCommand.resetPlugins()
         }

--- a/test/TerraformValidateStageTest.groovy
+++ b/test/TerraformValidateStageTest.groovy
@@ -1,20 +1,20 @@
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
-import static org.hamcrest.Matchers.isA
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.is
+import static org.hamcrest.CoreMatchers.instanceOf
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TerraformValidateStageTest {
-    @After
+    @AfterEach
     void resetPlugins() {
         TerraformValidateStage.resetPlugins()
     }
 
+    @Nested
     public class PipelineConfiguration {
         @Test
         void returnsAJobDslClosure() {
@@ -22,7 +22,7 @@ class TerraformValidateStageTest {
 
             def result = validateStage.pipelineConfiguration()
 
-            assertThat(result, isA(Closure.class))
+            assertThat(result, is(instanceOf(Closure.class)))
         }
 
         // This should be split into separate tests, and assert behavior
@@ -38,6 +38,7 @@ class TerraformValidateStageTest {
         }
     }
 
+    @Nested
     public class Then {
         @Test
         void nextStageisCalled() {
@@ -46,10 +47,11 @@ class TerraformValidateStageTest {
 
             def result = stage.then(stage2)
 
-            assertThat(result, isA(BuildGraph.class))
+            assertThat(result, is(instanceOf(BuildGraph.class)))
         }
     }
 
+    @Nested
     public class Build {
         @Test
         void justExerciseNoAssertions() {
@@ -59,6 +61,7 @@ class TerraformValidateStageTest {
         }
     }
 
+    @Nested
     public class Decorate {
         @Test
         void justExerciseNoAssertions() {

--- a/test/TfvarsFilesPluginTest.groovy
+++ b/test/TfvarsFilesPluginTest.groovy
@@ -3,14 +3,12 @@ import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.not
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 
-import de.bechte.junit.runners.context.HierarchicalContextRunner
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class TfvarsFilesPluginTest {
 
     static void setupOriginalContext() {
@@ -47,8 +45,9 @@ class TfvarsFilesPluginTest {
         TfvarsFilesPlugin.directory = '.'
     }
 
+    @Nested
     class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             reset()
         }
@@ -70,8 +69,9 @@ class TfvarsFilesPluginTest {
         }
     }
 
+    @Nested
     class Directory {
-        @After
+        @AfterEach
         void resetPlugins() {
             reset()
         }
@@ -84,9 +84,10 @@ class TfvarsFilesPluginTest {
         }
     }
 
+    @Nested
     class ApplyCommand {
 
-        @After
+        @AfterEach
         void resetPlugins() {
             reset()
         }
@@ -143,9 +144,10 @@ class TfvarsFilesPluginTest {
         }
     }
 
+    @Nested
     class PlanCommand {
 
-        @After
+        @AfterEach
         void resetPlugins() {
             reset()
         }

--- a/test/ValidateFormatPluginTest.groovy
+++ b/test/ValidateFormatPluginTest.groovy
@@ -1,21 +1,19 @@
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class ValidateFormatPluginTest {
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         TerraformValidateStage.resetPlugins()
         TerraformFormatCommand.reset()
@@ -38,6 +36,7 @@ class ValidateFormatPluginTest {
         }
     }
 
+    @Nested
     public class ApplyForValidateStage {
         @Test
         void addsClosureToRunTerraformFormat() {
@@ -52,6 +51,7 @@ class ValidateFormatPluginTest {
         }
     }
 
+    @Nested
     public class FormatClosure {
         @Test
         void runsTheGivenInnerClosure() {

--- a/test/WithAwsPluginTest.groovy
+++ b/test/WithAwsPluginTest.groovy
@@ -1,19 +1,17 @@
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.Matchers.is
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
-import org.junit.After
-import org.junit.Test
-import org.junit.runner.RunWith
-import de.bechte.junit.runners.context.HierarchicalContextRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-@RunWith(HierarchicalContextRunner.class)
 class WithAwsPluginTest {
-    @After
+    @AfterEach
     void reset() {
         Jenkinsfile.instance = mock(Jenkinsfile.class)
         when(Jenkinsfile.instance.getEnv()).thenReturn([:])
@@ -26,8 +24,9 @@ class WithAwsPluginTest {
         when(Jenkinsfile.instance.getEnv()).thenReturn(config.env ?: [:])
     }
 
+    @Nested
     public class Init {
-        @After
+        @AfterEach
         void resetPlugins() {
             TerraformEnvironmentStage.reset()
         }
@@ -46,10 +45,11 @@ class WithAwsPluginTest {
         void isFluentAndReturnsThePluginClass() {
             def result = WithAwsPlugin.withRole()
 
-            assertTrue(result == WithAwsPlugin.class)
+            assertThat(result, equalTo(WithAwsPlugin))
         }
     }
 
+    @Nested
     public class WithImplicitRole {
         @Test
         void returnsGenericRoleIfPresent() {
@@ -103,6 +103,7 @@ class WithAwsPluginTest {
         }
     }
 
+    @Nested
     public class WithExplicitRole {
         @Test
         void returnsProvidedRole() {


### PR DESCRIPTION
* Issue #332 
* Replace Junit 4 with Junit 5.7
  * JUnit no longer supports `assertThat` for third-party libraries, so convert `org.junit.Assert.assertThat` to `org.hamcrest.MatcherAssert.assertThat` when hamcrest matchers are being used
  * Push towards using hamcrest matchers in general, over JUnit assertions.
  * `@Nested` in Junit 5 allows us to drop the hierarchicalcontextrunner dependency.  Be sure to apply it consistently going forward.
* Upgrade hamcrest from 1.3 to 2.2 
  * Junit 4 pulled in hamcrest dependencies, and Junit 5 no longer does this.  Swtich from hamcrest library to hamcrest dependency - this fixes the `java.lang.NoSuchMethodError: org/hamcrest/Matcher.describeMismatch` errors).
