### PR TITLE
Issue 331: terraform-pipeline should not fail if DockerPipeline plugin not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #331](https://github.com/manheim/terraform-pipeline/issues/331) Bug Fix: terraform-pipeline should be usable even if Docker-Pipeline-plugin is not installed (and Docker featuers are not used)
 * [Issue #335](https://github.com/manheim/terraform-pipeline/issues/335) Testing: Rename DummyJenkinsfile to MockWorkflowScript to better distinguish Jenkinsfile references.
 * [Issue #271](https://github.com/manheim/terraform-pipeline/issues/271) Testing: Cleanup Test resets for any static state.  New Resettable and ResetStaticStateExtension available.
 * [Issue #332](https://github.com/manheim/terraform-pipeline/issues/332) Upgrade from Junit 4 to 5.7, upgrade hamcrest from 1.3 to 2.2, remove junit-hierarchicalcontextrunner dependency

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -1,6 +1,5 @@
 class Jenkinsfile implements Resettable {
     public static original
-    public static docker
     public static defaultNodeName
     public static repoSlug = null
     public static instance = new Jenkinsfile()
@@ -56,7 +55,6 @@ class Jenkinsfile implements Resettable {
 
     def static void init(original, Class customizations=null) {
         this.original = original
-        this.docker   = original.docker
 
         initializeDefaultPlugins()
 
@@ -134,7 +132,6 @@ class Jenkinsfile implements Resettable {
         instance = new Jenkinsfile()
         original = null
         defaultNodeName = null
-        docker = null
         pipelineTemplate = null
         declarative = false
     }

--- a/test/AgentNodePluginTest.groovy
+++ b/test/AgentNodePluginTest.groovy
@@ -125,7 +125,6 @@ class AgentNodePluginTest {
                 AgentNodePlugin.withAgentDockerImageOptions(expectedOptions)
                 def plugin = new AgentNodePlugin()
                 def original = createOriginalSpy()
-                original.docker = original
 
                 def agentClosure = plugin.addAgent()
                 agentClosure.delegate = original


### PR DESCRIPTION
* Issue #331 
* How to reproduce: 
    * Have a jenkins instance that does not have Docker Pipeline plugin installed
    * Load a terraform-pipeline project in Jenkins, and load the library with `Jenkinsfile.init(this)`
    * __Expected:__ the pipeline loads with no error
    * __Actual:__ the pipeline errors with: 
```
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: docker for class: WorkflowScript
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.getProperty(ScriptBytecodeAdapter.java:458)
	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.getProperty(DefaultInvoker.java:39)
	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
	at Jenkinsfile.init(Jenkinsfile.groovy:59)
	at Jenkinsfile.init(Jenkinsfile.groovy)
```
* `Jenkinsfile` constructor captures the WorkflowScript's docker value.  This value only exists if the DockerPipeline is not installed.  If it's not installed, terraform-pipeline cannot function (even if you're not using docker features), because `Jenkinsfile.init(this)` fails.
* The docker reference in `Jenkinsfile` is actually dead code - remove it.  This fixes the failing `Jenkinsfile.init(this)` if DockerPIpeline plugin is not installed.