### PR TITLE
Issue 320: Fix bug in GithubPRPlugin, stop pipeline and display error on plan failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [Issue #320](https://github.com/manheim/terraform-pipeline/issues/320) Bug Fix: GithubPRPlugin should stop on plan errors, and display error to the user.
 * [Issue #331](https://github.com/manheim/terraform-pipeline/issues/331) Bug Fix: terraform-pipeline should be usable even if Docker-Pipeline-plugin is not installed (and Docker featuers are not used)
 * [Issue #335](https://github.com/manheim/terraform-pipeline/issues/335) Testing: Rename DummyJenkinsfile to MockWorkflowScript to better distinguish Jenkinsfile references.
 * [Issue #271](https://github.com/manheim/terraform-pipeline/issues/271) Testing: Cleanup Test resets for any static state.  New Resettable and ResetStaticStateExtension available.

--- a/src/GithubPRPlanPlugin.groovy
+++ b/src/GithubPRPlanPlugin.groovy
@@ -46,7 +46,13 @@ class GithubPRPlanPlugin implements TerraformPlanCommandPlugin, TerraformEnviron
 
     public Closure addComment(String env) {
         return { closure ->
-            closure()
+            try {
+                closure()
+            } catch (err) {
+                echo "terraform plan failed:"
+                sh "cat plan.err"
+                throw err
+            }
 
             if (isPullRequest()) {
                 String url = getPullRequestCommentUrl()

--- a/src/GithubPRPlanPlugin.groovy
+++ b/src/GithubPRPlanPlugin.groovy
@@ -38,6 +38,7 @@ class GithubPRPlanPlugin implements TerraformPlanCommandPlugin, TerraformEnviron
 
     @Override
     public void apply(TerraformPlanCommand command) {
+        command.withPrefix("set -o pipefail;")
         command.withArgument("-out=tfplan")
         command.withStandardErrorRedirection('plan.err')
         command.withSuffix('| tee plan.out')


### PR DESCRIPTION
* Issue #320 
* The Plugin incorrectly swallows plan errors (due to an always-successful `tee` command).
* Fail the pipeline on plan errors, and display the plan results to the user.
* Continue to behave normally if there are no plan errors.