### PR TITLE
Feature: Show environment on confirm apply page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [Issue #347](https://github.com/manheim/terraform-pipeline/pull/348)
   Feature: TerraformOutputOnlyPlugin - can restrict a pipeline run to
   displaying the current state outputs only via new job parameters.
+* [Issue #318](https://github.com/manheim/terraform-pipeline/issues/318) Feature: Show environment on confirm command page
 
 # v5.15
 

--- a/src/ConfirmApplyPlugin.groovy
+++ b/src/ConfirmApplyPlugin.groovy
@@ -6,7 +6,7 @@ class ConfirmApplyPlugin implements TerraformEnvironmentStagePlugin, Resettable 
     public static parameters = []
     public static confirmConditions = []
     public static enabled = true
-    public static String confirmMessage = 'Are you absolutely sure the plan above is correct, and should be IMMEDIATELY DEPLOYED via "terraform apply"?'
+    public static String confirmMessage = 'Are you absolutely sure the plan above is correct, and should be IMMEDIATELY DEPLOYED via "terraform apply" on stage ${environment}?'
     public static String okMessage = 'Run terraform apply now'
     public static String submitter
 


### PR DESCRIPTION
When asked to confirm the apply currently it takes you to a page with standard messaging identical for all environments. This PR gives a little more context on which environment your confirming

Closes #318 