### PR TITLE
Issue #354: Add taint and untaint command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [Issue #347](https://github.com/manheim/terraform-pipeline/pull/348) Feature: TerraformOutputOnlyPlugin - can restrict a pipeline run to displaying the current state outputs only via new job parameters.
 * [Issue #318](https://github.com/manheim/terraform-pipeline/issues/318) Feature: Show environment on confirm command page
 * [Issue #349](https://github.com/manheim/terraform-pipeline/pull/349) Extract plugin handling to a `Pluggable` trait to DRY up the existing TerraformCommand classes.
+* [Issue #354](https://github.com/manheim/terraform-pipeline/issues/354) Feature: Add TerraformTaintPlugin - Allows performing `terraform taint` or `terraform untaint` prior to the plan phase.
 
 # v5.15
 

--- a/docs/TerraformTaintPlugin.md
+++ b/docs/TerraformTaintPlugin.md
@@ -22,8 +22,6 @@ Jenkinsfile.init(this, env)
 
 // This enables the "taint" and "untaint" functionality
 // It will only apply to the master branch (default behavior)
-// and will only apply if the current worspace code is checked out from the
-// MyOrg/myrepo repository.
 TerraformTaintPlugin.init()
 
 def validate = new TerraformValidateStage()

--- a/docs/TerraformTaintPlugin.md
+++ b/docs/TerraformTaintPlugin.md
@@ -1,0 +1,46 @@
+## [TerraformTaintPlugin](../src/TerraformTaintPlugin.groovy)
+
+Enable this plugin to add `TAINT_RESOURCE` and `UNTAINT_RESOURCE` parameters
+to the build. If a resource path is provided via one of those parameters, then
+the `terraform plan` command will be preceded by the corresponding Terraform
+command to taint or untaint the appropriate resources.
+
+Note that the untaint command will take precedence, so if for some reason the
+same resource is placed in both parameters, it will be tainted and immediately
+untainted, resulting in no change.
+
+There are several ways to customize where and when the taint/untaint can run:
+
+* `onlyOnOriginRepo()`: This method takes in a string of the form
+  `<userOrOrg>/<repoName>`. When specified, the plugin will only apply when
+  the current checkout is from the same repository and not a fork or other
+  clone.
+* `onMasterOnly()`: This takes no arguments. This restricts the plugin from
+  applying to any branch other than master. This is the default behavior.
+* `onBranch()`: This takes in a branch name as a parameter. This adds the
+  branch to the list of approved branches.
+
+```
+// Jenkinsfile
+@Library(['terraform-pipeline@v3.10']) _
+
+Jenkinsfile.init(this, env)
+
+// This enables the "taint" and "untaint" functionality
+// It will only apply to the master branch (default behavior)
+// and will only apply if the current worspace code is checked out from the
+// MyOrg/myrepo repository.
+TerraformTaintPlugin.init()
+TerraformTaintPlugin.onlyOnOriginRepo("MyOrg/myrepo")
+
+def validate = new TerraformValidateStage()
+
+def destroyQa = new TerraformEnvironmentStage('qa')
+def destroyUat = new TerraformEnvironmentStage('uat')
+def destroyProd = new TerraformEnvironmentStage('prod')
+
+validate.then(destroyQa)
+        .then(destroyUat)
+        .then(destroyProd)
+        .build()
+```

--- a/docs/TerraformTaintPlugin.md
+++ b/docs/TerraformTaintPlugin.md
@@ -11,12 +11,6 @@ untainted, resulting in no change.
 
 There are several ways to customize where and when the taint/untaint can run:
 
-* `onlyOnOriginRepo()`: This method takes in a string of the form
-  `<userOrOrg>/<repoName>`. When specified, the plugin will only apply when
-  the current checkout is from the same repository and not a fork or other
-  clone.
-* `onMasterOnly()`: This takes no arguments. This restricts the plugin from
-  applying to any branch other than master. This is the default behavior.
 * `onBranch()`: This takes in a branch name as a parameter. This adds the
   branch to the list of approved branches.
 
@@ -31,7 +25,6 @@ Jenkinsfile.init(this, env)
 // and will only apply if the current worspace code is checked out from the
 // MyOrg/myrepo repository.
 TerraformTaintPlugin.init()
-TerraformTaintPlugin.onlyOnOriginRepo("MyOrg/myrepo")
 
 def validate = new TerraformValidateStage()
 

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -1,14 +1,10 @@
-class TerraformTaintCommand implements TerraformCommand {
+class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTaintCommandPlugin> {
   private static DEFAULT_BRANCHES = ['master']
   private static branches = DEFAULT_BRANCHES
 
-  String environment
   private String originRepoSlug = ""
-  private String terraformBinary = "terraform"
   private String command = "taint"
   private String resource
-  private static plugins = []
-  private appliedPlugins = []
 
   public TerraformTaintCommand(String environment) {
     this.environment = environment
@@ -43,9 +39,7 @@ class TerraformTaintCommand implements TerraformCommand {
     return this.environment
   }
 
-  public String toString() {
-    applyPluginsOnce()
-
+  public String assembleCommandString() {
     def parts = []
     parts << terraformBinary
     parts << command
@@ -53,19 +47,6 @@ class TerraformTaintCommand implements TerraformCommand {
 
     parts.removeAll { it == null }
     return parts.join(' ')
-  }
-
-  public static addPlugin(TerraformFormatCommandPlugin plugin) {
-    this.globalPlugins << plugin
-  }
-
-  private applyPluginsOnce() {
-    def remainingPlugins = globalPlugins - appliedPlugins
-
-    for (TerraformFormatCommandPlugin plugin in remainingPlugins) {
-      plugin.apply(this)
-      appliedPlugins << plugin
-    }
   }
 }
 

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -1,52 +1,36 @@
-class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTaintCommandPlugin> {
-  private static DEFAULT_BRANCHES = ['master']
-  private static branches = DEFAULT_BRANCHES
-
-  private String originRepoSlug = ""
+class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTaintCommandPlugin>, Resettable {
   private String command = "taint"
   private String resource
 
   public TerraformTaintCommand(String environment) {
     this.environment = environment
-    this.plugins = BuildWithParametersPlugin
-  }
-
-  public TerraformTaintCommand withOriginRepo(String originRepoSlug) {
-    this.originRepoSlug = originRepoSlug
-    return this
-  }
-
-  public TerraformTaintCommand onMasterOnly() {
-    this.branches = ['master']
-    return this
-  }
-
-  public TerraformTaintCommand onAnyBranch() {
-    this.branches = ['any']
-    return this
-  }
-
-  public TerraformTaintCommand onBranch(String branchName) {
-    this.branches << branchName
-    return this
   }
 
   public TerraformTaintCommand withResource(String resource) {
     this.resource = resource
-  }
 
-  public String getEnvironment() {
-    return this.environment
+    return this
   }
 
   public String assembleCommandString() {
-    def parts = []
-    parts << terraformBinary
-    parts << command
-    parts << resource
+    if (resource) {
+      def parts = []
+      parts << terraformBinary
+      parts << command
+      parts << resource
 
-    parts.removeAll { it == null }
-    return parts.join(' ')
+      parts.removeAll { it == null }
+      return parts.join(' ')
+    }
+
+    return "echo \"No resource set, skipping 'terraform taint'."
+  }
+
+  public static reset() {
+    this.plugins = []
+  }
+
+  public String getResource() {
+    return this.resource
   }
 }
-

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -38,4 +38,30 @@ class TerraformTaintCommand implements TerraformCommand {
   public String getEnvironment() {
     return this.environment
   }
+
+  public String toString() {
+    applyPluginsOnce()
+
+    def pattern
+    def parts = []
+    parts << terraformBinary
+    parts << command
+
+    parts.removeAll { it == null }
+    return parts.join(' ')
+  }
+
+  public static addPlugin(TerraformFormatCommandPlugin plugin) {
+    this.globalPlugins << plugin
+  }
+
+  private applyPluginsOnce() {
+    def remainingPlugins = globalPlugins - appliedPlugins
+
+    for (TerraformFormatCommandPlugin plugin in remainingPlugins) {
+      plugin.apply(this)
+      appliedPlugins << plugin
+    }
+  }
 }
+

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -1,6 +1,7 @@
-class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTaintCommandPlugin>, Resettable {
+class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTaintCommandPlugin> {
     private String command = "taint"
     private String resource
+    private String environment
 
     public TerraformTaintCommand(String environment) {
         this.environment = environment
@@ -12,10 +13,11 @@ class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTain
         return this
     }
 
-    public String assembleCommandString() {
+    public String toString() {
+        applyPlugins()
         if (resource) {
             def parts = []
-            parts << terraformBinary
+            parts << 'terraform'
             parts << command
             parts << resource
 
@@ -26,15 +28,15 @@ class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTain
         return "echo \"No resource set, skipping 'terraform taint'."
     }
 
-    public static reset() {
-        this.plugins = []
-    }
-
     public String getResource() {
         return this.resource
     }
 
     public static TerraformTaintCommand instanceFor(String environment) {
         return new TerraformTaintCommand(environment)
+    }
+
+    public String getEnvironment() {
+        return this.environment
     }
 }

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -1,0 +1,41 @@
+class TerraformTaintCommand implements TerraformCommand {
+  private static DEFAULT_BRANCHES = ['master']
+  private static branches = DEFAULT_BRANCHES
+
+  String environment
+  private String originRepoSlug = ""
+  private String terraformBinary = "terraform"
+  private String command = "taint"
+  private String args = []
+  private static plugins = []
+  private appliedPlugins = []
+
+  public TerraformTaintCommand(String environment) {
+    this.environment = environment
+    this.plugins = BuildWithParametersPlugin
+  }
+
+  public TerraformTaintCommand withOriginRepo(String originRepoSlug) {
+    this.originRepoSlug = originRepoSlug
+    return this
+  }
+
+  public TerraformTaintCommand onMasterOnly() {
+    this.branches = ['master']
+    return this
+  }
+
+  public TerraformTaintCommand onAnyBranch() {
+    this.branches = ['any']
+    return this
+  }
+
+  public TerraformTaintCommand onBranch(String branchName) {
+    this.branches << branchName
+    return this
+  }
+
+  public String getEnvironment() {
+    return this.environment
+  }
+}

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -9,23 +9,18 @@ class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTain
 
     public TerraformTaintCommand withResource(String resource) {
         this.resource = resource
-
         return this
     }
 
     public String toString() {
         applyPlugins()
-        if (resource) {
-            def parts = []
-            parts << 'terraform'
-            parts << command
-            parts << resource
+        def parts = []
+        parts << 'terraform'
+        parts << command
+        parts << resource
 
-            parts.removeAll { it == null }
-            return parts.join(' ')
-        }
-
-        return "echo \"No resource set, skipping 'terraform taint'."
+        parts.removeAll { it == null }
+        return parts.join(' ')
     }
 
     public String getResource() {

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -1,36 +1,40 @@
 class TerraformTaintCommand implements TerraformCommand, Pluggable<TerraformTaintCommandPlugin>, Resettable {
-  private String command = "taint"
-  private String resource
+    private String command = "taint"
+    private String resource
 
-  public TerraformTaintCommand(String environment) {
-    this.environment = environment
-  }
-
-  public TerraformTaintCommand withResource(String resource) {
-    this.resource = resource
-
-    return this
-  }
-
-  public String assembleCommandString() {
-    if (resource) {
-      def parts = []
-      parts << terraformBinary
-      parts << command
-      parts << resource
-
-      parts.removeAll { it == null }
-      return parts.join(' ')
+    public TerraformTaintCommand(String environment) {
+        this.environment = environment
     }
 
-    return "echo \"No resource set, skipping 'terraform taint'."
-  }
+    public TerraformTaintCommand withResource(String resource) {
+        this.resource = resource
 
-  public static reset() {
-    this.plugins = []
-  }
+        return this
+    }
 
-  public String getResource() {
-    return this.resource
-  }
+    public String assembleCommandString() {
+        if (resource) {
+            def parts = []
+            parts << terraformBinary
+            parts << command
+            parts << resource
+
+            parts.removeAll { it == null }
+            return parts.join(' ')
+        }
+
+        return "echo \"No resource set, skipping 'terraform taint'."
+    }
+
+    public static reset() {
+        this.plugins = []
+    }
+
+    public String getResource() {
+        return this.resource
+    }
+
+    public static TerraformTaintCommand instanceFor(String environment) {
+        return new TerraformTaintCommand(environment)
+    }
 }

--- a/src/TerraformTaintCommand.groovy
+++ b/src/TerraformTaintCommand.groovy
@@ -6,7 +6,7 @@ class TerraformTaintCommand implements TerraformCommand {
   private String originRepoSlug = ""
   private String terraformBinary = "terraform"
   private String command = "taint"
-  private String args = []
+  private String resource
   private static plugins = []
   private appliedPlugins = []
 
@@ -35,6 +35,10 @@ class TerraformTaintCommand implements TerraformCommand {
     return this
   }
 
+  public TerraformTaintCommand withResource(String resource) {
+    this.resource = resource
+  }
+
   public String getEnvironment() {
     return this.environment
   }
@@ -42,10 +46,10 @@ class TerraformTaintCommand implements TerraformCommand {
   public String toString() {
     applyPluginsOnce()
 
-    def pattern
     def parts = []
     parts << terraformBinary
     parts << command
+    parts << resource
 
     parts.removeAll { it == null }
     return parts.join(' ')

--- a/src/TerraformTaintCommandPlugin.groovy
+++ b/src/TerraformTaintCommandPlugin.groovy
@@ -1,0 +1,26 @@
+interface TerraformTaintCommandPlugin {
+    public void apply(TerraformTaintCommand command)
+}
+
+public class TerraformTaintCommandPluginImpl implements TerraformEnvironmentStagePlugin, TerraformTaintCommandPlugin {
+    private String[] resources
+
+    public static void init() {
+        TerraformTaintCommandPlugin plugin = new TerraformTaintCommandPluginImpl();
+
+        BuildWithParametersPlugin.withStringParameter([
+            name: "TAINT_RESOURCES",
+            description: 'Run \`terraform taint\` on the resources specified prior to planning and applying.'
+        ])
+
+        BuildWithParametersPlugin.withStringParameter([
+            name: "UNTAINT_RESOURCES",
+            description: 'Run \`terraform untaint\` on the resources specified prior to planning and applying.'
+        ])
+
+        TerraformEnvironmentStage.addPlugin(plugin)
+    }
+
+    public Closure onlyOnExpectedBranch() {}
+    public boolean shouldApply() {}
+}

--- a/src/TerraformTaintCommandPlugin.groovy
+++ b/src/TerraformTaintCommandPlugin.groovy
@@ -1,26 +1,3 @@
 interface TerraformTaintCommandPlugin {
     public void apply(TerraformTaintCommand command)
 }
-
-public class TerraformTaintCommandPluginImpl implements TerraformEnvironmentStagePlugin, TerraformTaintCommandPlugin {
-    private String[] resources
-
-    public static void init() {
-        TerraformTaintCommandPlugin plugin = new TerraformTaintCommandPluginImpl();
-
-        BuildWithParametersPlugin.withStringParameter([
-            name: "TAINT_RESOURCES",
-            description: 'Run \`terraform taint\` on the resources specified prior to planning and applying.'
-        ])
-
-        BuildWithParametersPlugin.withStringParameter([
-            name: "UNTAINT_RESOURCES",
-            description: 'Run \`terraform untaint\` on the resources specified prior to planning and applying.'
-        ])
-
-        TerraformEnvironmentStage.addPlugin(plugin)
-    }
-
-    public Closure onlyOnExpectedBranch() {}
-    public boolean shouldApply() {}
-}

--- a/src/TerraformTaintPlugin.groovy
+++ b/src/TerraformTaintPlugin.groovy
@@ -60,7 +60,7 @@ class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, Terraform
     public Closure runTerraformTaintCommand(String environment) {
         def taintCommand = TerraformTaintCommand.instanceFor(environment)
         return { closure ->
-            if (taintCommand.resource && shouldApply()) {
+            if (shouldApply()) {
                 echo "Running '${taintCommand.toString()}'. TerraformTaintPlugin is enabled."
                 sh taintCommand.toString()
             }
@@ -71,7 +71,7 @@ class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, Terraform
     public Closure runTerraformUntaintCommand(String environment) {
         def untaintCommand = TerraformUntaintCommand.instanceFor(environment)
         return { closure ->
-            if (untaintCommand.resource && shouldApply()) {
+            if (shouldApply()) {
                 echo "Running '${untaintCommand.toString()}'. TerraformTaintPlugin is enabled."
                 sh untaintCommand.toString()
             }

--- a/src/TerraformTaintPlugin.groovy
+++ b/src/TerraformTaintPlugin.groovy
@@ -1,0 +1,121 @@
+import static TerraformEnvironmentStage.PLAN_COMMAND
+
+class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, TerraformTaintCommandPlugin, TerraformUntaintCommandPlugin, Resettable {
+    public static String origin_repo = ''
+    private static DEFAULT_BRANCHES = ['master']
+    private static branches = DEFAULT_BRANCHES
+
+    public static void init() {
+        TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+
+        BuildWithParametersPlugin.withStringParameter([
+            name: "TAINT_RESOURCE",
+            description: 'Run `terraform taint` on the resource specified prior to planning and applying.'
+        ])
+
+        BuildWithParametersPlugin.withStringParameter([
+            name: "UNTAINT_RESOURCE",
+            description: 'Run `terraform untaint` on the resource specified prior to planning and applying.'
+        ])
+
+        TerraformEnvironmentStage.addPlugin(plugin)
+        TerraformTaintCommand.addPlugin(plugin)
+        TerraformUntaintCommand.addPlugin(plugin)
+    }
+
+    public static withOriginRepo(String origin_repo) {
+        this.origin_repo = origin_repo
+        return this
+    }
+
+    public static onMasterOnly() {
+        this.branches = ['master']
+        return this
+    }
+
+    public static onBranch(String branchName) {
+        this.branches << branchName
+        return this
+    }
+
+    public void apply(TerraformEnvironmentStage stage) {
+        stage.decorate(PLAN_COMMAND, runTerraformTaintCommand(stage.getEnvironment()))
+        stage.decorate(PLAN_COMMAND, runTerraformUntaintCommand(stage.getEnvironment()))
+    }
+
+    public void apply(TerraformTaintCommand command) {
+        def resource = Jenkinsfile.instance.getEnv().TAINT_RESOURCE
+        if (resource) {
+            command.withResource(resource)
+        }
+    }
+
+    public void apply(TerraformUntaintCommand command) {
+        def resource = Jenkinsfile.instance.getEnv().UNTAINT_RESOURCE
+        if (resource) {
+            command.withResource(resource)
+        }
+    }
+
+    public boolean shouldApply() {
+        def apply = false
+        def current_repo = repoSlug(Jenkinsfile.instance.getEnv().GIT_URL)
+
+        // Check branches
+        if (branches.contains(Jenkinsfile.instance.getEnv().BRANCH_NAME)) {
+            apply = true
+        } else if (null == Jenkinsfile.instance.getEnv().BRANCH_NAME) {
+            apply = true
+        }
+
+        // Check repo slug
+        if (current_repo.toLowerCase() == this.origin_repo.toLowerCase()) {
+            apply = apply && true
+        } else if (! this.origin_repo) { // We assume that no origin repo means run always
+            apply = apply && true
+        } else { // We don't have a match, so reset apply
+            apply = false
+        }
+
+        return apply
+    }
+
+    private String repoSlug(String originUrl) {
+        if (! originUrl.endsWith('.git')) { originUrl = "${originUrl}.git" }
+        def giturl = originUrl =~ /^.*@.*[:\/]([^\/]+\/.*)\.git$/
+        def httpurl = originUrl =~ /^https?:\/\/[^\/]+\/([^\/]+\/[^\/]+)\.git$/
+        if ( giturl.matches() ) {
+            return giturl[0][1]
+        } else if ( httpurl.matches() ) {
+            return httpurl[0][1]
+        }
+        return ""
+    }
+
+    public Closure runTerraformTaintCommand(String environment) {
+        def taintCommand = TerraformTaintCommand.instanceFor(environment)
+        return { closure ->
+            if (taintCommand.resource && shouldApply()) {
+                echo "Running '${taintCommand.toString()}'. TerraformTaintPlugin is enabled."
+                sh taintCommand.toString()
+            }
+            closure()
+        }
+    }
+
+    public Closure runTerraformUntaintCommand(String environment) {
+        def untaintCommand = TerraformUntaintCommand.instanceFor(environment)
+        return { closure ->
+            if (untaintCommand.resource && shouldApply()) {
+                echo "Running '${untaintCommand.toString()}'. TerraformTaintPlugin is enabled."
+                sh untaintCommand.toString()
+            }
+            closure()
+        }
+    }
+
+    public static reset() {
+        this.origin_repo = ''
+        this.branches = DEFAULT_BRANCHES.clone()
+    }
+}

--- a/src/TerraformTaintPlugin.groovy
+++ b/src/TerraformTaintPlugin.groovy
@@ -1,7 +1,6 @@
 import static TerraformEnvironmentStage.PLAN_COMMAND
 
 class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, TerraformTaintCommandPlugin, TerraformUntaintCommandPlugin, Resettable {
-    public static String origin_repo = ''
     private static DEFAULT_BRANCHES = ['master']
     private static branches = DEFAULT_BRANCHES
 
@@ -21,16 +20,6 @@ class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, Terraform
         TerraformEnvironmentStage.addPlugin(plugin)
         TerraformTaintCommand.addPlugin(plugin)
         TerraformUntaintCommand.addPlugin(plugin)
-    }
-
-    public static onlyOnOriginRepo(String origin_repo) {
-        this.origin_repo = origin_repo
-        return this
-    }
-
-    public static onMasterOnly() {
-        this.branches = ['master']
-        return this
     }
 
     public static onBranch(String branchName) {
@@ -58,38 +47,14 @@ class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, Terraform
     }
 
     public boolean shouldApply() {
-        def apply = false
-        def current_repo = repoSlug(Jenkinsfile.instance.getEnv().GIT_URL)
-
         // Check branches
         if (branches.contains(Jenkinsfile.instance.getEnv().BRANCH_NAME)) {
-            apply = true
+            return true
         } else if (null == Jenkinsfile.instance.getEnv().BRANCH_NAME) {
-            apply = true
+            return true
         }
 
-        // Check repo slug
-        if (current_repo.toLowerCase() == this.origin_repo.toLowerCase()) {
-            apply = apply && true
-        } else if (! this.origin_repo) { // We assume that no origin repo means run always
-            apply = apply && true
-        } else { // We don't have a match, so reset apply
-            apply = false
-        }
-
-        return apply
-    }
-
-    private String repoSlug(String originUrl) {
-        if (! originUrl.endsWith('.git')) { originUrl = "${originUrl}.git" }
-        def giturl = originUrl =~ /^.*@.*[:\/]([^\/]+\/.*)\.git$/
-        def httpurl = originUrl =~ /^https?:\/\/[^\/]+\/([^\/]+\/[^\/]+)\.git$/
-        if ( giturl.matches() ) {
-            return giturl[0][1]
-        } else if ( httpurl.matches() ) {
-            return httpurl[0][1]
-        }
-        return ""
+        return false
     }
 
     public Closure runTerraformTaintCommand(String environment) {
@@ -115,7 +80,6 @@ class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, Terraform
     }
 
     public static reset() {
-        this.origin_repo = ''
         this.branches = DEFAULT_BRANCHES.clone()
     }
 }

--- a/src/TerraformTaintPlugin.groovy
+++ b/src/TerraformTaintPlugin.groovy
@@ -23,7 +23,7 @@ class TerraformTaintPlugin implements TerraformEnvironmentStagePlugin, Terraform
         TerraformUntaintCommand.addPlugin(plugin)
     }
 
-    public static withOriginRepo(String origin_repo) {
+    public static onlyOnOriginRepo(String origin_repo) {
         this.origin_repo = origin_repo
         return this
     }

--- a/src/TerraformUntaintCommand.groovy
+++ b/src/TerraformUntaintCommand.groovy
@@ -1,6 +1,7 @@
-class TerraformUntaintCommand implements TerraformCommand, Pluggable<TerraformUntaintCommandPlugin>, Resettable {
+class TerraformUntaintCommand implements TerraformCommand, Pluggable<TerraformUntaintCommandPlugin> {
     private String command = "untaint"
     private String resource
+    private String environment
 
     public TerraformUntaintCommand(String environment) {
         this.environment = environment
@@ -12,10 +13,11 @@ class TerraformUntaintCommand implements TerraformCommand, Pluggable<TerraformUn
         return this
     }
 
-    public String assembleCommandString() {
+    public String toString() {
+        applyPlugins()
         if (resource) {
             def parts = []
-            parts << terraformBinary
+            parts << 'terraform'
             parts << command
             parts << resource
 
@@ -26,16 +28,16 @@ class TerraformUntaintCommand implements TerraformCommand, Pluggable<TerraformUn
         return "echo \"No resource set, skipping 'terraform untaint'."
     }
 
-    public static reset() {
-        this.plugins = []
-    }
-
     public String getResource() {
         return this.resource
     }
 
     public static TerraformUntaintCommand instanceFor(String environment) {
         return new TerraformUntaintCommand(environment)
+    }
+
+    public String getEnvironment() {
+        return this.environment
     }
 }
 

--- a/src/TerraformUntaintCommand.groovy
+++ b/src/TerraformUntaintCommand.groovy
@@ -1,37 +1,41 @@
 class TerraformUntaintCommand implements TerraformCommand, Pluggable<TerraformUntaintCommandPlugin>, Resettable {
-  private String command = "untaint"
-  private String resource
+    private String command = "untaint"
+    private String resource
 
-  public TerraformUntaintCommand(String environment) {
-    this.environment = environment
-  }
-
-  public TerraformUntaintCommand withResource(String resource) {
-    this.resource = resource
-
-    return this
-  }
-
-  public String assembleCommandString() {
-    if (resource) {
-      def parts = []
-      parts << terraformBinary
-      parts << command
-      parts << resource
-
-      parts.removeAll { it == null }
-      return parts.join(' ')
+    public TerraformUntaintCommand(String environment) {
+        this.environment = environment
     }
 
-    return "echo \"No resource set, skipping 'terraform untaint'."
-  }
+    public TerraformUntaintCommand withResource(String resource) {
+        this.resource = resource
 
-  public static reset() {
-    this.plugins = []
-  }
+        return this
+    }
 
-  public String getResource() {
-    return this.resource
-  }
+    public String assembleCommandString() {
+        if (resource) {
+            def parts = []
+            parts << terraformBinary
+            parts << command
+            parts << resource
+
+            parts.removeAll { it == null }
+            return parts.join(' ')
+        }
+
+        return "echo \"No resource set, skipping 'terraform untaint'."
+    }
+
+    public static reset() {
+        this.plugins = []
+    }
+
+    public String getResource() {
+        return this.resource
+    }
+
+    public static TerraformUntaintCommand instanceFor(String environment) {
+        return new TerraformUntaintCommand(environment)
+    }
 }
 

--- a/src/TerraformUntaintCommand.groovy
+++ b/src/TerraformUntaintCommand.groovy
@@ -1,0 +1,37 @@
+class TerraformUntaintCommand implements TerraformCommand, Pluggable<TerraformUntaintCommandPlugin>, Resettable {
+  private String command = "untaint"
+  private String resource
+
+  public TerraformUntaintCommand(String environment) {
+    this.environment = environment
+  }
+
+  public TerraformUntaintCommand withResource(String resource) {
+    this.resource = resource
+
+    return this
+  }
+
+  public String assembleCommandString() {
+    if (resource) {
+      def parts = []
+      parts << terraformBinary
+      parts << command
+      parts << resource
+
+      parts.removeAll { it == null }
+      return parts.join(' ')
+    }
+
+    return "echo \"No resource set, skipping 'terraform untaint'."
+  }
+
+  public static reset() {
+    this.plugins = []
+  }
+
+  public String getResource() {
+    return this.resource
+  }
+}
+

--- a/src/TerraformUntaintCommand.groovy
+++ b/src/TerraformUntaintCommand.groovy
@@ -9,23 +9,18 @@ class TerraformUntaintCommand implements TerraformCommand, Pluggable<TerraformUn
 
     public TerraformUntaintCommand withResource(String resource) {
         this.resource = resource
-
         return this
     }
 
     public String toString() {
         applyPlugins()
-        if (resource) {
-            def parts = []
-            parts << 'terraform'
-            parts << command
-            parts << resource
+        def parts = []
+        parts << 'terraform'
+        parts << command
+        parts << resource
 
-            parts.removeAll { it == null }
-            return parts.join(' ')
-        }
-
-        return "echo \"No resource set, skipping 'terraform untaint'."
+        parts.removeAll { it == null }
+        return parts.join(' ')
     }
 
     public String getResource() {

--- a/src/TerraformUntaintCommandPlugin.groovy
+++ b/src/TerraformUntaintCommandPlugin.groovy
@@ -1,0 +1,3 @@
+interface TerraformUntaintCommandPlugin {
+    public void apply(TerraformUntaintCommand command)
+}

--- a/test/TerraformTaintCommandTest.groovy
+++ b/test/TerraformTaintCommandTest.groovy
@@ -1,5 +1,3 @@
-import static org.hamcrest.Matchers.containsString
-import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.mock

--- a/test/TerraformTaintCommandTest.groovy
+++ b/test/TerraformTaintCommandTest.groovy
@@ -1,0 +1,79 @@
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.not
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ResetStaticStateExtension.class)
+class TerraformTaintCommandTest {
+    @Nested
+    public class WithResource {
+        @Test
+        void defaultsToEmpty() {
+            def command = new TerraformTaintCommand()
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, equalTo("echo \"No resource set, skipping 'terraform taint'."))
+        }
+
+        @Test
+        void addsResourceWhenSet() {
+            def command = new TerraformTaintCommand().withResource("foo")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, equalTo("terraform taint foo"))
+        }
+    }
+
+    @Nested
+    public class Plugins {
+        @Test
+        void areAppliedToTheCommand() {
+            TerraformTaintCommandPlugin plugin = mock(TerraformTaintCommandPlugin.class)
+            TerraformTaintCommand.addPlugin(plugin)
+
+            TerraformTaintCommand command = new TerraformTaintCommand()
+            command.environment = "env"
+            command.toString()
+
+            verify(plugin).apply(command)
+        }
+
+        @Test
+        void areAppliedExactlyOnce() {
+            TerraformTaintCommandPlugin plugin = mock(TerraformTaintCommandPlugin.class)
+            TerraformTaintCommand.addPlugin(plugin)
+
+            TerraformTaintCommand command = new TerraformTaintCommand()
+            command.environment = "env"
+
+            String firstCommand = command.toString()
+            String secondCommand = command.toString()
+
+            verify(plugin, times(1)).apply(command)
+        }
+
+        @Test
+        void areAppliedEvenAfterCommandAlreadyInstantiated() {
+            TerraformTaintCommandPlugin firstPlugin = mock(TerraformTaintCommandPlugin.class)
+            TerraformTaintCommandPlugin secondPlugin = mock(TerraformTaintCommandPlugin.class)
+
+            TerraformTaintCommand.addPlugin(firstPlugin)
+            TerraformTaintCommand command = new TerraformTaintCommand()
+            command.environment = "env"
+
+            TerraformTaintCommand.addPlugin(secondPlugin)
+
+            command.toString()
+
+            verify(firstPlugin, times(1)).apply(command)
+            verify(secondPlugin, times(1)).apply(command)
+        }
+    }
+}

--- a/test/TerraformTaintCommandTest.groovy
+++ b/test/TerraformTaintCommandTest.groovy
@@ -17,7 +17,7 @@ class TerraformTaintCommandTest {
             def command = new TerraformTaintCommand()
 
             def actualCommand = command.toString()
-            assertThat(actualCommand, equalTo("echo \"No resource set, skipping 'terraform taint'."))
+            assertThat(actualCommand, equalTo("terraform taint"))
         }
 
         @Test

--- a/test/TerraformTaintPluginTest.groovy
+++ b/test/TerraformTaintPluginTest.groovy
@@ -118,35 +118,6 @@ class TerraformTaintPluginTest {
     @Nested
     public class ShouldApply {
         @Test
-        void returnsTrueWhenNoOriginRepoSet() {
-            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
-            MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/username/repo'])
-
-            def result = plugin.shouldApply()
-            assertThat(result, equalTo(true))
-        }
-
-        @Test
-        void returnsFalseWhenOriginRepoMismatch() {
-            TerraformTaintPlugin.onlyOnOriginRepo('username/repo')
-            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
-            MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/fork/repo'])
-
-            def result = plugin.shouldApply()
-            assertThat(result, equalTo(false))
-        }
-
-        @Test
-        void returnsTrueWhenOriginRepoMatches() {
-            TerraformTaintPlugin.onlyOnOriginRepo('username/repo')
-            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
-            MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/username/repo'])
-
-            def result = plugin.shouldApply()
-            assertThat(result, equalTo(true))
-        }
-
-        @Test
         void returnsFalseWhenWrongBranch() {
             TerraformTaintPlugin plugin = new TerraformTaintPlugin()
             MockJenkinsfile.withEnv(['BRANCH_NAME': 'notmaster', 'GIT_URL': 'https://git.foo/username/repo'])

--- a/test/TerraformTaintPluginTest.groovy
+++ b/test/TerraformTaintPluginTest.groovy
@@ -1,0 +1,187 @@
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ResetStaticStateExtension.class)
+class TerraformTaintPluginTest {
+    @Nested
+    public class Init {
+        @Test
+        void modifiesTerraformEnvironmentStageCommand() {
+            TerraformTaintPlugin.init()
+
+            Collection actualPlugins = TerraformEnvironmentStage.getPlugins()
+            assertThat(actualPlugins, hasItem(instanceOf(TerraformTaintPlugin.class)))
+        }
+
+        @Test
+        void addsTaintResourceParameter() {
+            TerraformTaintPlugin.init()
+
+            def parametersPlugin = new BuildWithParametersPlugin()
+            Collection actualParms = parametersPlugin.getBuildParameters()
+
+            assertThat(actualParms, hasItem([
+                $class: 'hudson.model.StringParameterDefinition',
+                name: "TAINT_RESOURCE",
+                defaultValue: "",
+                description: 'Run `terraform taint` on the resource specified prior to planning and applying.'
+            ]))
+        }
+
+        @Test
+        void addsUntaintResourceParameter() {
+            TerraformTaintPlugin.init()
+
+            def parametersPlugin = new BuildWithParametersPlugin()
+            Collection actualParms = parametersPlugin.getBuildParameters()
+
+            assertThat(actualParms, hasItem([
+                $class: 'hudson.model.StringParameterDefinition',
+                name: "UNTAINT_RESOURCE",
+                defaultValue: "",
+                description: 'Run `terraform untaint` on the resource specified prior to planning and applying.'
+            ]))
+        }
+    }
+
+    @Nested
+    public class Apply {
+        @Test
+        void decoratesThePlanCommand() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            def environment = spy(new TerraformEnvironmentStage())
+            plugin.apply(environment)
+
+            verify(environment, times(2)).decorate(eq(TerraformEnvironmentStage.PLAN_COMMAND), any(Closure.class))
+        }
+
+        @Test
+        void skipsTaintWhenNoResource() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            def command = spy(new TerraformTaintCommand('env'))
+            MockJenkinsfile.withEnv([
+                'TAINT_RESOURCE': ''
+            ])
+            plugin.apply(command)
+
+            verify(command, times(0)).withResource()
+        }
+
+        @Test
+        void setsTaintResource() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            def command = spy(new TerraformTaintCommand('env'))
+            MockJenkinsfile.withEnv([
+                'TAINT_RESOURCE': 'foo.bar'
+            ])
+            plugin.apply(command)
+
+            verify(command, times(1)).withResource(eq('foo.bar'))
+        }
+
+        @Test
+        void skipsUntaintWhenNoResource() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            def command = spy(new TerraformUntaintCommand('env'))
+            MockJenkinsfile.withEnv([
+                'UNTAINT_RESOURCE': ''
+            ])
+            plugin.apply(command)
+
+            verify(command, times(0)).withResource()
+        }
+
+        @Test
+        void setsUntaintResource() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            def command = spy(new TerraformUntaintCommand('env'))
+            MockJenkinsfile.withEnv([
+                'UNTAINT_RESOURCE': 'foo.bar'
+            ])
+            plugin.apply(command)
+
+            verify(command, times(1)).withResource(eq('foo.bar'))
+        }
+    }
+
+    @Nested
+    public class ShouldApply {
+        @Test
+        void returnsTrueWhenNoOriginRepoSet() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/username/repo'])
+
+            def result = plugin.shouldApply()
+            assertThat(result, equalTo(true))
+        }
+
+        @Test
+        void returnsFalseWhenOriginRepoMismatch() {
+            TerraformTaintPlugin.withOriginRepo('username/repo')
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/fork/repo'])
+
+            def result = plugin.shouldApply()
+            assertThat(result, equalTo(false))
+        }
+
+        @Test
+        void returnsTrueWhenOriginRepoMatches() {
+            TerraformTaintPlugin.withOriginRepo('username/repo')
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/username/repo'])
+
+            def result = plugin.shouldApply()
+            assertThat(result, equalTo(true))
+        }
+
+        @Test
+        void returnsFalseWhenWrongBranch() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            MockJenkinsfile.withEnv(['BRANCH_NAME': 'notmaster', 'GIT_URL': 'https://git.foo/username/repo'])
+
+            def result = plugin.shouldApply()
+            assertThat(result, equalTo(false))
+        }
+
+        @Test
+        void usesMasterAsDefaultBranch() {
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/username/repo'])
+
+            def result = plugin.shouldApply()
+            assertThat(result, equalTo(true))
+        }
+
+        @Test
+        void returnsTrueWhenOnCorrectCustomBranch() {
+            TerraformTaintPlugin.onBranch("main")
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            MockJenkinsfile.withEnv(['BRANCH_NAME': 'main', 'GIT_URL': 'https://git.foo/username/repo'])
+
+            def result = plugin.shouldApply()
+            assertThat(result, equalTo(true))
+         }
+
+        @Test
+        void worksWithMultipleCustomBranches() {
+            TerraformTaintPlugin.onBranch("main").onBranch("notmaster")
+            TerraformTaintPlugin plugin = new TerraformTaintPlugin()
+            MockJenkinsfile.withEnv(['BRANCH_NAME': 'notmaster', 'GIT_URL': 'https://git.foo/username/repo'])
+
+            def result = plugin.shouldApply()
+            assertThat(result, equalTo(true))
+         }
+    }
+}

--- a/test/TerraformTaintPluginTest.groovy
+++ b/test/TerraformTaintPluginTest.groovy
@@ -128,7 +128,7 @@ class TerraformTaintPluginTest {
 
         @Test
         void returnsFalseWhenOriginRepoMismatch() {
-            TerraformTaintPlugin.withOriginRepo('username/repo')
+            TerraformTaintPlugin.onlyOnOriginRepo('username/repo')
             TerraformTaintPlugin plugin = new TerraformTaintPlugin()
             MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/fork/repo'])
 
@@ -138,7 +138,7 @@ class TerraformTaintPluginTest {
 
         @Test
         void returnsTrueWhenOriginRepoMatches() {
-            TerraformTaintPlugin.withOriginRepo('username/repo')
+            TerraformTaintPlugin.onlyOnOriginRepo('username/repo')
             TerraformTaintPlugin plugin = new TerraformTaintPlugin()
             MockJenkinsfile.withEnv(['BRANCH_NAME': 'master', 'GIT_URL': 'https://git.foo/username/repo'])
 

--- a/test/TerraformUntaintCommandTest.groovy
+++ b/test/TerraformUntaintCommandTest.groovy
@@ -1,0 +1,79 @@
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.not
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.times
+import static org.mockito.Mockito.verify
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ResetStaticStateExtension.class)
+class TerraformUntaintCommandTest {
+    @Nested
+    public class WithResource {
+        @Test
+        void defaultsToEmpty() {
+            def command = new TerraformUntaintCommand()
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, equalTo("echo \"No resource set, skipping 'terraform untaint'."))
+        }
+
+        @Test
+        void addsResourceWhenSet() {
+            def command = new TerraformUntaintCommand().withResource("foo")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, equalTo("terraform untaint foo"))
+        }
+    }
+
+    @Nested
+    public class Plugins {
+        @Test
+        void areAppliedToTheCommand() {
+            TerraformUntaintCommandPlugin plugin = mock(TerraformUntaintCommandPlugin.class)
+            TerraformUntaintCommand.addPlugin(plugin)
+
+            TerraformUntaintCommand command = new TerraformUntaintCommand()
+            command.environment = "env"
+            command.toString()
+
+            verify(plugin).apply(command)
+        }
+
+        @Test
+        void areAppliedExactlyOnce() {
+            TerraformUntaintCommandPlugin plugin = mock(TerraformUntaintCommandPlugin.class)
+            TerraformUntaintCommand.addPlugin(plugin)
+
+            TerraformUntaintCommand command = new TerraformUntaintCommand()
+            command.environment = "env"
+
+            String firstCommand = command.toString()
+            String secondCommand = command.toString()
+
+            verify(plugin, times(1)).apply(command)
+        }
+
+        @Test
+        void areAppliedEvenAfterCommandAlreadyInstantiated() {
+            TerraformUntaintCommandPlugin firstPlugin = mock(TerraformUntaintCommandPlugin.class)
+            TerraformUntaintCommandPlugin secondPlugin = mock(TerraformUntaintCommandPlugin.class)
+
+            TerraformUntaintCommand.addPlugin(firstPlugin)
+            TerraformUntaintCommand command = new TerraformUntaintCommand()
+            command.environment = "env"
+
+            TerraformUntaintCommand.addPlugin(secondPlugin)
+
+            command.toString()
+
+            verify(firstPlugin, times(1)).apply(command)
+            verify(secondPlugin, times(1)).apply(command)
+        }
+    }
+}

--- a/test/TerraformUntaintCommandTest.groovy
+++ b/test/TerraformUntaintCommandTest.groovy
@@ -1,5 +1,3 @@
-import static org.hamcrest.Matchers.containsString
-import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.mock

--- a/test/TerraformUntaintCommandTest.groovy
+++ b/test/TerraformUntaintCommandTest.groovy
@@ -17,7 +17,7 @@ class TerraformUntaintCommandTest {
             def command = new TerraformUntaintCommand()
 
             def actualCommand = command.toString()
-            assertThat(actualCommand, equalTo("echo \"No resource set, skipping 'terraform untaint'."))
+            assertThat(actualCommand, equalTo("terraform untaint"))
         }
 
         @Test


### PR DESCRIPTION
The `TerraformTaintPlugin` adds new parameters to a build for resources to taint / untaint. If nothing is specified, then the plugin does nothing. If a value is provided in one of the parameters, then the corresponding command will be ran prior to the `terraform plan` command. It also includes support for restricting the execution to a given branch or set of branches, as well as restricting based the origin repository of the code checked out in the workspace.

```
// Jenkinsfile
@Library(['terraform-pipeline@v3.10']) _

Jenkinsfile.init(this, env)

// This enables the "taint" and "untaint" functionality
// It will only apply to the master branch (default behavior)
// and will only apply if the current worspace code is checked out from the
// MyOrg/myrepo repository.
TerraformTaintPlugin.init()
TerraformTaintPlugin.onlyOnOriginRepo("MyOrg/myrepo")

def validate = new TerraformValidateStage()

def destroyQa = new TerraformEnvironmentStage('qa')
def destroyUat = new TerraformEnvironmentStage('uat')
def destroyProd = new TerraformEnvironmentStage('prod')

validate.then(destroyQa)
        .then(destroyUat)
        .then(destroyProd)
        .build()
```

Fixes #354 