### PR TITLE
Optionally enable echo on flyway CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [Issue #318](https://github.com/manheim/terraform-pipeline/issues/318) Feature: Show environment on confirm command page
 * [Issue #354](https://github.com/manheim/terraform-pipeline/issues/354) Feature: Add TerraformTaintPlugin - Allows performing `terraform taint` or `terraform untaint` prior to the plan phase.
 * [Issue #21](https://github.com/manheim/terraform-pipeline/issues/21) Feature: Plugin to run database migration scripts
+* [Issue #363](https://github.com/manheim/terraform-pipeline/issues/363) Feature: Optionally disable echo on flyway CLI commands
 
 # v5.15
 

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -1,6 +1,7 @@
 class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     public static String passwordVariable
     public static String userVariable
+    public static boolean echoEnabled = false
 
     public static void init() {
         TerraformEnvironmentStage.addPlugin(new FlywayMigrationPlugin())
@@ -49,9 +50,14 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
     }
 
     public String buildFlywayCommand(FlywayCommand command) {
-        def pieces = ['set +x']
+        def pieces = []
+        if (!echoEnabled) {
+            pieces << 'set +x'
+        }
         pieces << command.toString()
-        pieces << 'set -x'
+        if (!echoEnabled) {
+            pieces << 'set -x'
+        }
 
         return pieces.join('\n')
     }
@@ -66,8 +72,14 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
         return this
     }
 
+    public static withEchoEnabled(boolean trueOrFalse = true) {
+        this.echoEnabled = trueOrFalse
+        return this
+    }
+
     public static reset() {
         passwordVariable = null
         userVariable = null
+        echoEnabled = false
     }
 }

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -18,7 +18,7 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
             def environmentVariables = buildEnvironmentVariableList(env)
             withEnv(environmentVariables) {
                 def command = new FlywayCommand('info')
-                sh command.toString()
+                sh buildFlywayCommand(command)
             }
         }
     }
@@ -30,7 +30,7 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
             def environmentVariables = buildEnvironmentVariableList(env)
             withEnv(environmentVariables) {
                 def command = new FlywayCommand('migrate')
-                sh command.toString()
+                sh buildFlywayCommand(command)
             }
         }
     }
@@ -46,6 +46,14 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
         }
 
         return list
+    }
+
+    public String buildFlywayCommand(FlywayCommand command) {
+        def pieces = ['set +x']
+        pieces << command.toString()
+        pieces << 'set -x'
+
+        return pieces.join('\n')
     }
 
     public static withPasswordFromEnvironmentVariable(String passwordVariable) {

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -74,6 +74,16 @@ class FlywayMigrationPluginTest {
     }
 
     @Nested
+    public class WithEchoEnabled {
+        @Test
+        void isFluent() {
+            def result = FlywayMigrationPlugin.withEchoEnabled()
+
+            assertThat(result, equalTo(FlywayMigrationPlugin.class))
+        }
+    }
+
+    @Nested
     public class FlywayInfoClosure {
         @Test
         void runsTheNestedClosure() {
@@ -183,6 +193,19 @@ class FlywayMigrationPluginTest {
             def result = plugin.buildFlywayCommand(command)
 
             assertThat(result, equalTo("set +x\n${flywayCommand}\nset -x".toString()))
+        }
+
+        @Test
+        void returnsTheCommandIfEchoEnabled() {
+            def flywayCommand = 'flyway foo'
+            def command = mock(FlywayCommand.class)
+            doReturn(flywayCommand).when(command).toString()
+            def plugin = new FlywayMigrationPlugin()
+            FlywayMigrationPlugin.withEchoEnabled()
+
+            def result = plugin.buildFlywayCommand(command)
+
+            assertThat(result, equalTo(flywayCommand))
         }
     }
 }

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -170,5 +170,20 @@ class FlywayMigrationPluginTest {
             assertThat(result, equalTo(["FLYWAY_USER=${expectedValue}"]))
         }
     }
+
+    @Nested
+    public class BuildFlywayCommand {
+        @Test
+        void disablesEchoBeforeFlywayAndEnablesEchoAfterByDefault() {
+            def flywayCommand = 'flyway foo'
+            def command = mock(FlywayCommand.class)
+            doReturn(flywayCommand).when(command).toString()
+            def plugin = new FlywayMigrationPlugin()
+
+            def result = plugin.buildFlywayCommand(command)
+
+            assertThat(result, equalTo("set +x\n${flywayCommand}\nset -x".toString()))
+        }
+    }
 }
 


### PR DESCRIPTION
* Issue #363 
* By default, disable echo for the flyway CLI. (so that username/password is not echoed in Jenkins logs)
* Optionally allow echo to be enabled by the user