### PR TITLE
Issue 365: Make flyway configuration more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [Issue #354](https://github.com/manheim/terraform-pipeline/issues/354) Feature: Add TerraformTaintPlugin - Allows performing `terraform taint` or `terraform untaint` prior to the plan phase.
 * [Issue #21](https://github.com/manheim/terraform-pipeline/issues/21) Feature: Plugin to run database migration scripts
 * [Issue #363](https://github.com/manheim/terraform-pipeline/issues/363) Feature: Optionally disable echo on flyway CLI commands
+* [Issue #365](https://github.com/manheim/terraform-pipeline/issues/365) Feature: Optionally configure flyway username/password through CLI options
 
 # v5.15
 

--- a/docs/FlywayMigrationPlugin.md
+++ b/docs/FlywayMigrationPlugin.md
@@ -21,19 +21,42 @@ validate.then(deployQa)
         .build()
 ```
 
-If needed, flyway configuration can be set through the Plugin, or FlywayCommand.
+If needed, flyway configuration can be set through the FlywayCommand.
 
 ```
 @Library(['terraform-pipeline']) _
 Jenkinsfile.init(this, Customizations)
-// Use the FlywayCommand to modify specific options like `locations` and `url`
-FlywayCommand.withLocations("filesystem:`pwd`/migrations")
+// Use the FlywayCommand to modify specific options like `user`, `password`, `locations`, and `url`
+FlywayCommand.withUser("\$TF_VAR_USER")
+             .withPassword("\$TF_VAR_PASSWORD")
+             .withLocations("filesystem:`pwd`/migrations")
              .withUrl("`terraform output jdbc_url`")
-// Flyway automatically picks up specific enviornment variables (FLYWAY_USER, FLYWAY_PASSWORD)
-//     Sets FLYWAY_USER to the value of $TF_VAR_MIGRATION_USER
-//     Sets FLYWAY_PASSWORD to the value of $TF_VAR_MIGRATION_PASSWORD
-FlywayMigrationPlugin.withUserVariable('TF_VAR_MIGRATION_USER')
-                     .withPasswordVariable('TF_VAR_MIGRATION_PASSWORD')
+FlywayMigrationPlugin.init()
+
+def validate = new TerraformValidateStage()
+// For each environment
+//     Run the `flyway info` command after a successful `terraform plan`
+//     Run the `flyway migrate` command after a successful `terraform apply`
+def deployQa = new TerraformEnvironmentStage('qa')
+def deployUat = new TerraformEnvironmentStage('uat')
+def deployProd = new TerraformEnvironmentStage('prod')
+
+validate.then(deployQa)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```
+
+Or through existing environment variables and the FlywayMigrationPlugin.
+
+```
+@Library(['terraform-pipeline']) _
+Jenkinsfile.init(this, Customizations)
+// Allow flyway to be configured through standard environment variables
+FlywayMigrationPlugin.withMappedEnvironmentVariable('TF_VAR_USER', 'FLYWAY_USER')
+                     .withMappedEnvironmentVariable('TF_VAR_PASSWORD', 'FLYWAY_PASSWORD')
+                     .withMappedEnvironmentVariable('JDBC_URL', 'FLYWAY_URL')
+                     .withMappedEnvironmentVariable('LOCATIONS', 'FLYWAY_LOCATIONS')
                      .init()
 
 def validate = new TerraformValidateStage()

--- a/src/FlywayCommand.groovy
+++ b/src/FlywayCommand.groovy
@@ -4,6 +4,7 @@ class FlywayCommand implements Resettable {
     private static String locations
     private static String url
     private static String user
+    private static String password
 
     public FlywayCommand(String command) {
         this.command = command
@@ -26,11 +27,20 @@ class FlywayCommand implements Resettable {
             pieces << "-user=${user}"
         }
 
+        if (password) {
+            pieces << "-password=${password}"
+        }
+
         return pieces.join(' ')
     }
 
     public static withUser(String user) {
         this.user = user
+        return this
+    }
+
+    public static withPassword(String password) {
+        this.password = password
         return this
     }
 
@@ -48,5 +58,6 @@ class FlywayCommand implements Resettable {
         this.locations = null
         this.url = null
         this.user = null
+        this.password = null
     }
 }

--- a/src/FlywayCommand.groovy
+++ b/src/FlywayCommand.groovy
@@ -5,6 +5,7 @@ class FlywayCommand implements Resettable {
     private static String url
     private static String user
     private static String password
+    private static Collection additionalParameters = []
 
     public FlywayCommand(String command) {
         this.command = command
@@ -31,6 +32,8 @@ class FlywayCommand implements Resettable {
             pieces << "-password=${password}"
         }
 
+        pieces.addAll(additionalParameters)
+
         return pieces.join(' ')
     }
 
@@ -54,10 +57,17 @@ class FlywayCommand implements Resettable {
         return this
     }
 
+    public static withAdditionalParameter(String parameter) {
+        this.additionalParameters << parameter
+        println "withAdditionalParameter: ${parameter}, ${this.additionalParameters}"
+        return this
+    }
+
     public static reset() {
         this.locations = null
         this.url = null
         this.user = null
         this.password = null
+        this.additionalParameters = []
     }
 }

--- a/src/FlywayCommand.groovy
+++ b/src/FlywayCommand.groovy
@@ -3,6 +3,7 @@ class FlywayCommand implements Resettable {
     private String binary = "flyway"
     private static String locations
     private static String url
+    private static String user
 
     public FlywayCommand(String command) {
         this.command = command
@@ -21,7 +22,16 @@ class FlywayCommand implements Resettable {
             pieces << "-url=${url}"
         }
 
+        if (user) {
+            pieces << "-user=${user}"
+        }
+
         return pieces.join(' ')
+    }
+
+    public static withUser(String user) {
+        this.user = user
+        return this
     }
 
     public static withLocations(String locations) {
@@ -37,5 +47,6 @@ class FlywayCommand implements Resettable {
     public static reset() {
         this.locations = null
         this.url = null
+        this.user = null
     }
 }

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -55,18 +55,13 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
         return pieces.join('\n')
     }
 
-    public static withPasswordFromEnvironmentVariable(String passwordVariable) {
-        variableMap['FLYWAY_PASSWORD'] = passwordVariable
-        return this
-    }
-
-    public static withUserFromEnvironmentVariable(String userVariable) {
-        variableMap['FLYWAY_USER'] = userVariable
-        return this
-    }
-
     public static withEchoEnabled(boolean trueOrFalse = true) {
         this.echoEnabled = trueOrFalse
+        return this
+    }
+
+    public static withMappedEnvironmentVariable(String from, String to) {
+        variableMap[to] = from
         return this
     }
 

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -1,6 +1,5 @@
 class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettable {
-    public static String passwordVariable
-    public static String userVariable
+    public static Map<String,String> variableMap = [:]
     public static boolean echoEnabled = false
 
     public static void init() {
@@ -37,16 +36,10 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
     }
 
     public Collection buildEnvironmentVariableList(env) {
-        def list = []
-        if (passwordVariable) {
-            list << "FLYWAY_PASSWORD=${env[passwordVariable]}"
+        variableMap.inject([]) { list, key, value ->
+            list << "${key}=${env[value]}"
+            list
         }
-
-        if (userVariable) {
-            list << "FLYWAY_USER=${env[userVariable]}"
-        }
-
-        return list
     }
 
     public String buildFlywayCommand(FlywayCommand command) {
@@ -63,12 +56,12 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
     }
 
     public static withPasswordFromEnvironmentVariable(String passwordVariable) {
-        this.passwordVariable = passwordVariable
+        variableMap['FLYWAY_PASSWORD'] = passwordVariable
         return this
     }
 
     public static withUserFromEnvironmentVariable(String userVariable) {
-        this.userVariable = userVariable
+        variableMap['FLYWAY_USER'] = userVariable
         return this
     }
 
@@ -78,8 +71,7 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
     }
 
     public static reset() {
-        passwordVariable = null
-        userVariable = null
+        variableMap = [:]
         echoEnabled = false
     }
 }

--- a/test/FlywayCommandTest.groovy
+++ b/test/FlywayCommandTest.groovy
@@ -9,6 +9,16 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(ResetStaticStateExtension.class)
 class FlywayCommandTest {
     @Nested
+    public class WithUser {
+        @Test
+        void isfluent() {
+            def result = FlywayCommand.withUser('someUser')
+
+            assertThat(result, equalTo(FlywayCommand.class))
+        }
+    }
+
+    @Nested
     public class WithLocations {
         @Test
         void isFluent() {
@@ -37,6 +47,20 @@ class FlywayCommandTest {
             def result = command.toString()
 
             assertThat(result, equalTo("flyway info"))
+        }
+
+        @Nested
+        public class WithUser {
+            @Test
+            void includesTheUserParameter() {
+                def expectedUser = 'someUser'
+                FlywayCommand.withUser(expectedUser)
+                def command = new FlywayCommand('blah')
+
+                def result = command.toString()
+
+                assertThat(result, containsString("-user=${expectedUser}"))
+            }
         }
 
         @Nested

--- a/test/FlywayCommandTest.groovy
+++ b/test/FlywayCommandTest.groovy
@@ -49,6 +49,16 @@ class FlywayCommandTest {
     }
 
     @Nested
+    public class WithAdditionalParameter {
+        @Test
+        void isFluent() {
+            def result = FlywayCommand.withAdditionalParameter('-someParam=someValue')
+
+            assertThat(result, equalTo(FlywayCommand.class))
+        }
+    }
+
+    @Nested
     public class ToString {
         @Test
         void constructsTheCommand() {
@@ -112,6 +122,34 @@ class FlywayCommandTest {
                 def result = command.toString()
 
                 assertThat(result, containsString("-url=${expectedUrl}"))
+            }
+        }
+
+        @Nested
+        public class WithAdditionalParameters {
+            @Test
+            void addsTheAdditionalParameter() {
+                def expectedParameter = "-someParam=someValue"
+                FlywayCommand.withAdditionalParameter(expectedParameter)
+                def command = new FlywayCommand('blah')
+
+                def result = command.toString()
+
+                assertThat(result, containsString(expectedParameter))
+            }
+
+            @Test
+            void addsMultipleAdditionalParameters() {
+                def param1 = '-param1=value1'
+                def param2 = '-param2=value2'
+                FlywayCommand.withAdditionalParameter(param1)
+                             .withAdditionalParameter(param2)
+                def command = new FlywayCommand('blah')
+
+                def result = command.toString()
+
+                assertThat(result, containsString(param1))
+                assertThat(result, containsString(param2))
             }
         }
     }

--- a/test/FlywayCommandTest.groovy
+++ b/test/FlywayCommandTest.groovy
@@ -9,6 +9,26 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(ResetStaticStateExtension.class)
 class FlywayCommandTest {
     @Nested
+    public class WithLocations {
+        @Test
+        void isFluent() {
+            def result = FlywayCommand.withLocations('someLocations')
+
+            assertThat(result, equalTo(FlywayCommand.class))
+        }
+    }
+
+    @Nested
+    public class WithUrl {
+        @Test
+        void isFluent() {
+            def result = FlywayCommand.withUrl('someUrl')
+
+            assertThat(result, equalTo(FlywayCommand.class))
+        }
+    }
+
+    @Nested
     public class ToString {
         @Test
         void constructsTheCommand() {
@@ -21,13 +41,6 @@ class FlywayCommandTest {
 
         @Nested
         public class WithLocations {
-            @Test
-            void isFluent() {
-                def result = FlywayCommand.withLocations('someLocations')
-
-                assertThat(result, equalTo(FlywayCommand.class))
-            }
-
             @Test
             void includesTheLocationsParameter() {
                 def expectedLocations = 'filesystem:/some/dir'
@@ -42,13 +55,6 @@ class FlywayCommandTest {
 
         @Nested
         public class WithUrl {
-            @Test
-            void isFluent() {
-                def result = FlywayCommand.withUrl('someUrl')
-
-                assertThat(result, equalTo(FlywayCommand.class))
-            }
-
             @Test
             void includesTheUrlParameter() {
                 def expectedUrl = 'jdbc:mysql://someurl'

--- a/test/FlywayCommandTest.groovy
+++ b/test/FlywayCommandTest.groovy
@@ -19,6 +19,16 @@ class FlywayCommandTest {
     }
 
     @Nested
+    public class WithPassword {
+        @Test
+        void isfluent() {
+            def result = FlywayCommand.withPassword('somePassword')
+
+            assertThat(result, equalTo(FlywayCommand.class))
+        }
+    }
+
+    @Nested
     public class WithLocations {
         @Test
         void isFluent() {
@@ -60,6 +70,20 @@ class FlywayCommandTest {
                 def result = command.toString()
 
                 assertThat(result, containsString("-user=${expectedUser}"))
+            }
+        }
+
+        @Nested
+        public class WithPassword {
+            @Test
+            void includesThePasswordParameter() {
+                def expectedPassword = 'somePassword'
+                FlywayCommand.withPassword(expectedPassword)
+                def command = new FlywayCommand('blah')
+
+                def result = command.toString()
+
+                assertThat(result, containsString("-password=${expectedPassword}"))
             }
         }
 

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -54,20 +54,10 @@ class FlywayMigrationPluginTest {
     }
 
     @Nested
-    public class WithPasswordFromEnvironmentVariable {
+    public class WithMappedEnvironmentVariable {
         @Test
         void isFluent() {
-            def result = FlywayMigrationPlugin.withPasswordFromEnvironmentVariable('MY_PASSWORD')
-
-            assertThat(result, equalTo(FlywayMigrationPlugin.class))
-        }
-    }
-
-    @Nested
-    public class WithUserFromEnvironmentVariable {
-        @Test
-        void isFluent() {
-            def result = FlywayMigrationPlugin.withUserFromEnvironmentVariable('MY_USER')
+            def result = FlywayMigrationPlugin.withMappedEnvironmentVariable('TF_VAR_MY_USER', 'FLYWAY_USER')
 
             assertThat(result, equalTo(FlywayMigrationPlugin.class))
         }
@@ -155,29 +145,17 @@ class FlywayMigrationPluginTest {
         }
 
         @Test
-        void setsPasswordWhenVariableProvided() {
-            def expectedVariable = 'MY_PASSWORD_VARIABLE'
-            def expectedValue = 'somePass'
-            FlywayMigrationPlugin.withPasswordFromEnvironmentVariable(expectedVariable)
+        void mapsEnvironmentVariable() {
+            def toVariable = 'FLYWAY_USER'
+            def fromVariable = 'MY_USER_VARIABLE'
+            def fromValue = 'someUser'
+            FlywayMigrationPlugin.withMappedEnvironmentVariable(fromVariable, toVariable)
             def plugin = new FlywayMigrationPlugin()
-            def env = [(expectedVariable): expectedValue]
+            def env = [(fromVariable): fromValue]
 
             def result = plugin.buildEnvironmentVariableList(env)
 
-            assertThat(result, equalTo(["FLYWAY_PASSWORD=${expectedValue}"]))
-        }
-
-        @Test
-        void setsUserWhenVariableProvided() {
-            def expectedVariable = 'MY_USER_VARIABLE'
-            def expectedValue = 'someUser'
-            FlywayMigrationPlugin.withUserFromEnvironmentVariable(expectedVariable)
-            def plugin = new FlywayMigrationPlugin()
-            def env = [(expectedVariable): expectedValue]
-
-            def result = plugin.buildEnvironmentVariableList(env)
-
-            assertThat(result, equalTo(["FLYWAY_USER=${expectedValue}"]))
+            assertThat(result, equalTo(["${toVariable}=${fromValue}"]))
         }
     }
 


### PR DESCRIPTION
* Issue #365 
* Push username/password to FlywayCommand, so they can be passed as CLI parameters
* Add additional generic parameter to FlywayCommand, for all other options.
* Remove username/password environment variable mapping.  Replace with generic variable mapping.
