### PR TITLE
Issue 368: Prompt the user *again* if a pending migration is detected.  Optionally disable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [Issue #363](https://github.com/manheim/terraform-pipeline/issues/363) Feature: Optionally disable echo on flyway CLI commands
 * [Issue #365](https://github.com/manheim/terraform-pipeline/issues/365) Feature: Optionally configure flyway username/password through CLI options
 * [Issue #362](https://github.com/manheim/terraform-pipeline/issues/362) Bug Fix: Apply AnsiColorPlugin on `terraform validate` and `terraform init`
+* [Issue #368](https://github.com/manheim/terraform-pipeline/issues/368) Feature: Optionally prompt user *again* before applying migration.
 
 # v5.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [Issue #363](https://github.com/manheim/terraform-pipeline/issues/363) Feature: Optionally disable echo on flyway CLI commands
 * [Issue #365](https://github.com/manheim/terraform-pipeline/issues/365) Feature: Optionally configure flyway username/password through CLI options
 * [Issue #362](https://github.com/manheim/terraform-pipeline/issues/362) Bug Fix: Apply AnsiColorPlugin on `terraform validate` and `terraform init`
-* [Issue #368](https://github.com/manheim/terraform-pipeline/issues/368) Feature: Optionally prompt user *again* before applying migration.
+* [Issue #368](https://github.com/manheim/terraform-pipeline/issues/368) Feature: FlywayMigrationPlugin - prompt user *again* before applying migration.  Optionally disable prompt.
 
 # v5.15
 

--- a/docs/FlywayMigrationPlugin.md
+++ b/docs/FlywayMigrationPlugin.md
@@ -1,6 +1,6 @@
 ## [FlywayMigrationPlugin](../src/FlywayMigrationPlugin.groovy)
 
-Enable this plugin to run automated database migrations with [Flyway](https://flywaydb.org/).  Flyway can be configured through standard configuration files, or through environment variables.  Since migrations maybe less frequent than terrform changes, by default, if a pending migrtion is detected, the pipeline will prompt you *again* to confirm that you want to proceed with the migration.
+Enable this plugin to run automated database migrations with [Flyway](https://flywaydb.org/).  Flyway can be configured through standard configuration files, or through environment variables.  Since migrations may happen less frequently than terrform changes, by default, if a pending migration is detected the pipeline will prompt you *again* to confirm that you want to proceed with the migration.
 
 ```
 @Library(['terraform-pipeline']) _
@@ -78,11 +78,7 @@ If you don't want to be prompted a second time when migrations are detected, you
 ```
 @Library(['terraform-pipeline']) _
 Jenkinsfile.init(this, Customizations)
-// Use the FlywayCommand to modify specific options like `user`, `password`, `locations`, and `url`
-FlywayCommand.withUser("\$TF_VAR_USER")
-             .withPassword("\$TF_VAR_PASSWORD")
-             .withLocations("filesystem:`pwd`/migrations")
-             .withUrl("`terraform output jdbc_url`")
+// Disable second confirmation when pending migration is detected.
 FlywayMigrationPlugin.confirmBeforeApplyingMigration(false)
                      .init()
 

--- a/docs/FlywayMigrationPlugin.md
+++ b/docs/FlywayMigrationPlugin.md
@@ -1,6 +1,6 @@
 ## [FlywayMigrationPlugin](../src/FlywayMigrationPlugin.groovy)
 
-Enable this plugin to run automated database migrations with [Flyway](https://flywaydb.org/).  Flyway can be configured through standard configuration files, or through environment variables.
+Enable this plugin to run automated database migrations with [Flyway](https://flywaydb.org/).  Flyway can be configured through standard configuration files, or through environment variables.  Since migrations maybe less frequent than terrform changes, by default, if a pending migrtion is detected, the pipeline will prompt you *again* to confirm that you want to proceed with the migration.
 
 ```
 @Library(['terraform-pipeline']) _
@@ -73,7 +73,7 @@ validate.then(deployQa)
         .build()
 ```
 
-Since new migrations may be an infrequent occurrence, it may be easy to overlook migrations in the Plan stage.  You can optionally enable a *second* confirmation, when a Pending migration is detected using `FlywayMigrationPlugin.confirmBeforeApplyingMigration()`.  This is intended to bring added attention to migrations that will be run on the Apply stage.
+If you don't want to be prompted a second time when migrations are detected, you can disable the migration confirmation with `FlywayMigrationPlugin.confirmBeforeApplyingMigration(false)`.
 
 ```
 @Library(['terraform-pipeline']) _
@@ -83,7 +83,7 @@ FlywayCommand.withUser("\$TF_VAR_USER")
              .withPassword("\$TF_VAR_PASSWORD")
              .withLocations("filesystem:`pwd`/migrations")
              .withUrl("`terraform output jdbc_url`")
-FlywayMigrationPlugin.confirmBeforeApplyingMigration()
+FlywayMigrationPlugin.confirmBeforeApplyingMigration(false)
                      .init()
 
 Jenkinsfile.init(this, Customizations)

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -53,7 +53,13 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
             pieces << 'set -o pipefail'
         }
 
-        pieces << command.toString()
+        def commandString = command.toString()
+        if (confirmBeforeApply) {
+            commandString += "| tee flyway_output.txt"
+        }
+
+        pieces << commandString
+
         if (!echoEnabled) {
             pieces << 'set -x'
         }

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -65,6 +65,10 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
         return this
     }
 
+    public static confirmBeforeApplyingMigration() {
+        return this
+    }
+
     public static reset() {
         variableMap = [:]
         echoEnabled = false

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -1,6 +1,7 @@
 class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     public static Map<String,String> variableMap = [:]
     public static boolean echoEnabled = false
+    public static boolean confirmBeforeApply = false
 
     public static void init() {
         TerraformEnvironmentStage.addPlugin(new FlywayMigrationPlugin())
@@ -47,6 +48,11 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
         if (!echoEnabled) {
             pieces << 'set +x'
         }
+
+        if (confirmBeforeApply) {
+            pieces << 'set -o pipefail'
+        }
+
         pieces << command.toString()
         if (!echoEnabled) {
             pieces << 'set -x'
@@ -66,11 +72,13 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
     }
 
     public static confirmBeforeApplyingMigration() {
+        this.confirmBeforeApply = true
         return this
     }
 
     public static reset() {
         variableMap = [:]
         echoEnabled = false
+        confirmBeforeApply = false
     }
 }

--- a/src/FlywayMigrationPlugin.groovy
+++ b/src/FlywayMigrationPlugin.groovy
@@ -1,7 +1,7 @@
 class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     public static Map<String,String> variableMap = [:]
     public static boolean echoEnabled = false
-    public static boolean confirmBeforeApply = false
+    public static boolean confirmBeforeApply = true
 
     public static void init() {
         TerraformEnvironmentStage.addPlugin(new FlywayMigrationPlugin())
@@ -105,14 +105,14 @@ class FlywayMigrationPlugin implements TerraformEnvironmentStagePlugin, Resettab
         return this
     }
 
-    public static confirmBeforeApplyingMigration() {
-        this.confirmBeforeApply = true
+    public static confirmBeforeApplyingMigration(boolean trueOrFalse = true) {
+        this.confirmBeforeApply = trueOrFalse
         return this
     }
 
     public static reset() {
         variableMap = [:]
         echoEnabled = false
-        confirmBeforeApply = false
+        confirmBeforeApply = true
     }
 }

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -198,6 +198,16 @@ class FlywayMigrationPluginTest {
 
                 assertThat(result, containsString("set -o pipefail"))
             }
+
+            @Test
+            void pipesFlywayCommandWithToFileTee() {
+                def plugin = spy(new FlywayMigrationPlugin())
+                FlywayMigrationPlugin.confirmBeforeApplyingMigration()
+
+                def result = plugin.buildFlywayCommand(mock(FlywayCommand.class))
+
+                assertThat(result, containsString("| tee flyway_output.txt"))
+            }
         }
     }
 

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -186,5 +186,15 @@ class FlywayMigrationPluginTest {
             assertThat(result, equalTo(flywayCommand))
         }
     }
+
+    @Nested
+    public class ConfirmBeforeApplyingMigration {
+        @Test
+        void isFluent() {
+            def result = FlywayMigrationPlugin.confirmBeforeApplyingMigration()
+
+            assertThat(result, equalTo(FlywayMigrationPlugin.class))
+        }
+    }
 }
 

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -103,44 +103,6 @@ class FlywayMigrationPluginTest {
 
             verify(mockWorkflowScript).withEnv(eq(expectedList), any(Closure.class))
         }
-
-        @Test
-        void runsConfirmMigrationIfConfirmBeforeApplyAndHasPendingMigration() {
-            def plugin = spy(new FlywayMigrationPlugin())
-            doReturn(true).when(plugin).hasPendingMigration(any(Object.class))
-            FlywayMigrationPlugin.confirmBeforeApplyingMigration()
-
-            def flywayClosure = plugin.flywayInfoClosure()
-            flywayClosure.delegate = new MockWorkflowScript()
-            flywayClosure { -> }
-
-            verify(plugin).confirmMigration(any(Object.class))
-        }
-
-        @Test
-        void doesNotRunConfirmMigrationIfNotConfirmBeforeApplyAndHasPendingMigration() {
-            def plugin = spy(new FlywayMigrationPlugin())
-            doReturn(true).when(plugin).hasPendingMigration(any(Object.class))
-
-            def flywayClosure = plugin.flywayInfoClosure()
-            flywayClosure.delegate = new MockWorkflowScript()
-            flywayClosure { -> }
-
-            verify(plugin, times(0)).confirmMigration(any(Object.class))
-        }
-
-        @Test
-        void doesNotRunConfirmMigrationIfConfirmBeforeApplyAndDoesNotHavePendingMigration() {
-            def plugin = spy(new FlywayMigrationPlugin())
-            doReturn(false).when(plugin).hasPendingMigration(any(Object.class))
-            FlywayMigrationPlugin.confirmBeforeApplyingMigration()
-
-            def flywayClosure = plugin.flywayInfoClosure()
-            flywayClosure.delegate = new MockWorkflowScript()
-            flywayClosure { -> }
-
-            verify(plugin, times(0)).confirmMigration(any(Object.class))
-        }
     }
 
     @Nested
@@ -170,6 +132,44 @@ class FlywayMigrationPluginTest {
             flywayClosure { -> }
 
             verify(mockWorkflowScript).withEnv(eq(expectedList), any(Closure.class))
+        }
+
+        @Test
+        void runsConfirmMigrationIfConfirmBeforeApplyAndHasPendingMigration() {
+            def plugin = spy(new FlywayMigrationPlugin())
+            doReturn(true).when(plugin).hasPendingMigration(any(Object.class))
+            FlywayMigrationPlugin.confirmBeforeApplyingMigration()
+
+            def flywayClosure = plugin.flywayMigrateClosure()
+            flywayClosure.delegate = new MockWorkflowScript()
+            flywayClosure { -> }
+
+            verify(plugin).confirmMigration(any(Object.class))
+        }
+
+        @Test
+        void doesNotRunConfirmMigrationIfNotConfirmBeforeApplyAndHasPendingMigration() {
+            def plugin = spy(new FlywayMigrationPlugin())
+            doReturn(true).when(plugin).hasPendingMigration(any(Object.class))
+
+            def flywayClosure = plugin.flywayMigrateClosure()
+            flywayClosure.delegate = new MockWorkflowScript()
+            flywayClosure { -> }
+
+            verify(plugin, times(0)).confirmMigration(any(Object.class))
+        }
+
+        @Test
+        void doesNotRunConfirmMigrationIfConfirmBeforeApplyAndDoesNotHavePendingMigration() {
+            def plugin = spy(new FlywayMigrationPlugin())
+            doReturn(false).when(plugin).hasPendingMigration(any(Object.class))
+            FlywayMigrationPlugin.confirmBeforeApplyingMigration()
+
+            def flywayClosure = plugin.flywayMigrateClosure()
+            flywayClosure.delegate = new MockWorkflowScript()
+            flywayClosure { -> }
+
+            verify(plugin, times(0)).confirmMigration(any(Object.class))
         }
     }
 

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -141,6 +141,7 @@ class FlywayMigrationPluginTest {
         void runsConfirmMigrationIfConfirmBeforeApplyAndHasPendingMigration() {
             def plugin = spy(new FlywayMigrationPlugin())
             doReturn(true).when(plugin).hasPendingMigration(any(Object.class))
+            FlywayMigrationPlugin.confirmBeforeApplyingMigration(true)
 
             def flywayClosure = plugin.flywayMigrateClosure()
             flywayClosure.delegate = new MockWorkflowScript()
@@ -166,7 +167,7 @@ class FlywayMigrationPluginTest {
         void doesNotRunConfirmMigrationIfConfirmBeforeApplyAndDoesNotHavePendingMigration() {
             def plugin = spy(new FlywayMigrationPlugin())
             doReturn(false).when(plugin).hasPendingMigration(any(Object.class))
-            FlywayMigrationPlugin.confirmBeforeApplyingMigration()
+            FlywayMigrationPlugin.confirmBeforeApplyingMigration(true)
 
             def flywayClosure = plugin.flywayMigrateClosure()
             flywayClosure.delegate = new MockWorkflowScript()
@@ -286,7 +287,7 @@ class FlywayMigrationPluginTest {
         }
 
         @Test
-        void pipesFlywayCommandWithToFileTee() {
+        void pipesFlywayCommandToFileWithTee() {
             def plugin = spy(new FlywayMigrationPlugin())
 
             def result = plugin.buildFlywayCommand(mock(FlywayCommand.class))
@@ -326,7 +327,7 @@ class FlywayMigrationPluginTest {
         @Nested
         public class WithConfirmBeforeApplyingMigrationDisabled {
             @Test
-            void prefixesFlywayCommandWithPipelineFail() {
+            void doesNotPrefixFlywayCommandWithPipelineFail() {
                 def plugin = spy(new FlywayMigrationPlugin())
                 FlywayMigrationPlugin.confirmBeforeApplyingMigration(false)
 
@@ -336,7 +337,7 @@ class FlywayMigrationPluginTest {
             }
 
             @Test
-            void pipesFlywayCommandWithToFileTee() {
+            void doesNotPipeFlywayCommandToFileWthTee() {
                 def plugin = spy(new FlywayMigrationPlugin())
                 FlywayMigrationPlugin.confirmBeforeApplyingMigration(false)
 

--- a/test/FlywayMigrationPluginTest.groovy
+++ b/test/FlywayMigrationPluginTest.groovy
@@ -1,6 +1,7 @@
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.mockito.Mockito.any
 import static org.mockito.Mockito.doReturn;
@@ -184,6 +185,19 @@ class FlywayMigrationPluginTest {
             def result = plugin.buildFlywayCommand(command)
 
             assertThat(result, equalTo(flywayCommand))
+        }
+
+        @Nested
+        public class WithConfirmBeforeApplyingMigration {
+            @Test
+            void prefixesFlywayCommandWithPipelineFail() {
+                def plugin = spy(new FlywayMigrationPlugin())
+                FlywayMigrationPlugin.confirmBeforeApplyingMigration()
+
+                def result = plugin.buildFlywayCommand(mock(FlywayCommand.class))
+
+                assertThat(result, containsString("set -o pipefail"))
+            }
         }
     }
 


### PR DESCRIPTION
* Issue #368 
* Applying a migration may be an uncommon case - more commonly, no pending migration may exist
* Because this is an uncommon occurrence, a user may not be accustomed to validating during the "plan" stage whether or not a pending migration exists.
* As an extra safe guard, optionally prompt the user *again* if a migration is detected - reconfirm that the user is aware that a pending migration exists, and approves the application of said migration.
* This should be optional