### PR TITLE
Issue 214: CredentialsPlugin - support more than username/password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [Issue #214](https://github.com/manheim/terraform-pipeline/issues/214) CredentialsPlugin: support more than username/password
 - [Issue #399](https://github.com/manheim/terraform-pipeline/issues/399) Add pull request templates, with checkboxes for necessary tasks
 - [Issue #309](https://github.com/manheim/terraform-pipeline/issues/309) Add the ability to specify terraform-pipeline starting execution workspace directory
 - [Issue #283](https://github.com/manheim/terraform-pipeline/issues/283) Remove CrqPlugin, as it relies on a Manheim internal tool that is deprecated. Users of CrqPlugin will find a replacement in the Manheim internal ``terraform-pipeline-cai-plugins`` project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [Issue #214](https://github.com/manheim/terraform-pipeline/issues/214) CredentialsPlugin: support more than username/password
+- [Issue #214](https://github.com/manheim/terraform-pipeline/issues/214) CredentialsPlugin: support more than username/password (Deprecate `withBuildCredentials`)
 - [Issue #399](https://github.com/manheim/terraform-pipeline/issues/399) Add pull request templates, with checkboxes for necessary tasks
 - [Issue #309](https://github.com/manheim/terraform-pipeline/issues/309) Add the ability to specify terraform-pipeline starting execution workspace directory
 - [Issue #283](https://github.com/manheim/terraform-pipeline/issues/283) Remove CrqPlugin, as it relies on a Manheim internal tool that is deprecated. Users of CrqPlugin will find a replacement in the Manheim internal ``terraform-pipeline-cai-plugins`` project.

--- a/docs/CredentialsPlugin.md
+++ b/docs/CredentialsPlugin.md
@@ -3,10 +3,10 @@
 Enable this plugin to inject credentials into your stages using the [Jenkins Credentials Plugin](https://wiki.jenkins.io/display/JENKINS/Credentials+Plugin).
 
 One-time setup:
-* Install the [Jenkins Credentials Plugin](https://wiki.jenkins.io/display/JENKINS/Credentials+Plugin) on your Jenkins master.
-* Define a credential that you want to inject.  Currently, only usernamePassword credentials are supported.
+* Install the [Jenkins Credentials Binding Plugin](https://www.jenkins.io/doc/pipeline/steps/credentials-binding/) on your Jenkins master.
+* Define a credential that you want to inject.
 
-Specify the credential that you want to inject in your stages.  Optionally provide custom username/password environment variables that will contain the credential values for your use.
+Add any number of credentials bindings that you want to wrap your stages, with `withBinding`.  Each call to this method cumulatively add more credentials.  See the [Credentials Binding Plugin homepage](https://www.jenkins.io/doc/pipeline/steps/credentials-binding/) for the list of supported bindings.
 
 ```
 // Jenkinsfile
@@ -14,8 +14,11 @@ Specify the credential that you want to inject in your stages.  Optionally provi
 
 Jenkinsfile.init(this)
 
-// MY_CREDENTIALS_USERNAME and MY_CREDENTIALS_PASSWORD will contain the respective username/password values of the 'my-credentials' credential.
-CredentialsPlugin.withBuildCredentials('my-credentials').init()
+// Add credentials to all Stages from usernamePassword, usernameColonPassowrd, and string credentials
+CredentialsPlugin.withBinding { usernamePassword(credentialsId: 'my-user-pass', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD') }
+                 .withBinding { usernameColonPassword(credentialsId: 'my-user-colon-pass', variable: 'USERPASS') }
+		 .withBinding { string(credentialsId: 'my-string-token', variable: 'TOKEN') }
+		 .init()
 
 def validate = new TerraformValidateStage()
 def build = new BuildStage()

--- a/docs/CredentialsPlugin.md
+++ b/docs/CredentialsPlugin.md
@@ -6,7 +6,7 @@ One-time setup:
 * Install the [Jenkins Credentials Binding Plugin](https://www.jenkins.io/doc/pipeline/steps/credentials-binding/) on your Jenkins master.
 * Define a credential that you want to inject.
 
-Add any number of credentials bindings that you want to wrap your stages, with `withBinding`.  Each call to this method cumulatively add more credentials.  See the [Credentials Binding Plugin homepage](https://www.jenkins.io/doc/pipeline/steps/credentials-binding/) for the list of supported bindings.
+Add any number of credentials bindings that you want to wrap your stages, with `withBinding`.  Each call to this method will cumulatively add more credentials.  See the [Credentials Binding Plugin homepage](https://www.jenkins.io/doc/pipeline/steps/credentials-binding/) for the list of supported bindings.
 
 ```
 // Jenkinsfile
@@ -14,7 +14,7 @@ Add any number of credentials bindings that you want to wrap your stages, with `
 
 Jenkinsfile.init(this)
 
-// Add credentials to all Stages from usernamePassword, usernameColonPassowrd, and string credentials
+// Add credentials to all Stages from usernamePassword, usernameColonPassword, and string credentials
 CredentialsPlugin.withBinding { usernamePassword(credentialsId: 'my-user-pass', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD') }
                  .withBinding { usernameColonPassword(credentialsId: 'my-user-colon-pass', variable: 'USERPASS') }
 		 .withBinding { string(credentialsId: 'my-string-token', variable: 'TOKEN') }

--- a/src/CredentialsPlugin.groovy
+++ b/src/CredentialsPlugin.groovy
@@ -1,5 +1,5 @@
 class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, TerraformEnvironmentStagePlugin, TerraformValidateStagePlugin, Resettable {
-    private static globalBuildCredentials = []
+    private static bindings = []
 
     public static void init() {
         def plugin = new CredentialsPlugin()
@@ -12,7 +12,7 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
 
     public static withBuildCredentials(Map options = [:], String credentialsId) {
         Map optionsWithDefaults = populateDefaults(options, credentialsId)
-        globalBuildCredentials << { usernamePassword(optionsWithDefaults) }
+        bindings << { usernamePassword(optionsWithDefaults) }
         return this
     }
 
@@ -38,9 +38,9 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
 
     private addBuildCredentials() {
         return { innerClosure ->
-            def credentials = globalBuildCredentials.collect { it -> it() }
+            def appliedBindings = bindings.collect { it -> it() }
 
-            withCredentials(credentials, innerClosure)
+            withCredentials(appliedBindings, innerClosure)
         }
     }
 
@@ -58,11 +58,11 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
     }
 
     public static getBuildCredentials() {
-        return globalBuildCredentials
+        return bindings
     }
 
     public static void reset() {
-        globalBuildCredentials = []
+        bindings = []
     }
 
 }

--- a/src/CredentialsPlugin.groovy
+++ b/src/CredentialsPlugin.groovy
@@ -44,7 +44,8 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
 
     private addBuildCredentials() {
         return { innerClosure ->
-            def appliedBindings = getBindings().collect { it -> it() }
+            def workflowScript = delegate
+            def appliedBindings = getBindings().collect { it -> it.delegate = workflowScript; it() }
 
             withCredentials(appliedBindings, innerClosure)
         }

--- a/src/CredentialsPlugin.groovy
+++ b/src/CredentialsPlugin.groovy
@@ -14,6 +14,8 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
         bindings << binding
         return this
     }
+
+    // Deprecated: Remove this with Issue #404 and the next major release
     public static withBuildCredentials(Map options = [:], String credentialsId) {
         Map optionsWithDefaults = populateDefaults(options, credentialsId)
         bindings << { usernamePassword(optionsWithDefaults) }

--- a/src/CredentialsPlugin.groovy
+++ b/src/CredentialsPlugin.groovy
@@ -12,6 +12,7 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
 
     public static withBinding(Closure binding) {
         bindings << binding
+        return this
     }
     public static withBuildCredentials(Map options = [:], String credentialsId) {
         Map optionsWithDefaults = populateDefaults(options, credentialsId)

--- a/src/CredentialsPlugin.groovy
+++ b/src/CredentialsPlugin.groovy
@@ -10,6 +10,9 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
         TerraformValidateStage.addPlugin(plugin)
     }
 
+    public static withBinding(Closure binding) {
+        bindings << binding
+    }
     public static withBuildCredentials(Map options = [:], String credentialsId) {
         Map optionsWithDefaults = populateDefaults(options, credentialsId)
         bindings << { usernamePassword(optionsWithDefaults) }

--- a/src/CredentialsPlugin.groovy
+++ b/src/CredentialsPlugin.groovy
@@ -57,7 +57,7 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
         value.toUpperCase().replaceAll('-', '_')
     }
 
-    public static getBuildCredentials() {
+    public static getBindings() {
         return bindings
     }
 

--- a/src/CredentialsPlugin.groovy
+++ b/src/CredentialsPlugin.groovy
@@ -44,7 +44,7 @@ class CredentialsPlugin implements BuildStagePlugin, RegressionStagePlugin, Terr
 
     private addBuildCredentials() {
         return { innerClosure ->
-            def appliedBindings = bindings.collect { it -> it() }
+            def appliedBindings = getBindings().collect { it -> it() }
 
             withCredentials(appliedBindings, innerClosure)
         }

--- a/test/CredentialsPluginTest.groovy
+++ b/test/CredentialsPluginTest.groovy
@@ -78,6 +78,7 @@ class CredentialsPluginTest {
         }
     }
 
+    // Deprecated: Remove this with Issue #404 and the next major release
     @Nested
     public class WithBuildCredentials {
         @Test

--- a/test/CredentialsPluginTest.groovy
+++ b/test/CredentialsPluginTest.groovy
@@ -48,6 +48,13 @@ class CredentialsPluginTest {
     @Nested
     public class WithBinding {
         @Test
+        void isFluent() {
+            def result = CredentialsPlugin.withBinding { }
+
+            assertThat(result, equalTo(CredentialsPlugin))
+        }
+
+        @Test
         void addsABinding() {
             def binding = { usernameColonPassword(credentialsId: 'my-user-colon-pass', variable: 'USERPASS') }
             CredentialsPlugin.withBinding(binding)

--- a/test/CredentialsPluginTest.groovy
+++ b/test/CredentialsPluginTest.groovy
@@ -48,20 +48,20 @@ class CredentialsPluginTest {
     @Nested
     public class WithBuildCredentials {
         @Test
-        void addsCredentialsForBuildStage() {
+        void addsUsernamePasswordBindingForBuildStage() {
             CredentialsPlugin.withBuildCredentials("credentials1")
 
-            def buildCredentials = CredentialsPlugin.getBuildCredentials()
-            assertThat(buildCredentials, hasSize(1))
+            def bindings = CredentialsPlugin.getBindings()
+            assertThat(bindings, hasSize(1))
         }
 
         @Test
-        void addsMultipleCredentialsForBuildStage() {
+        void addsMultipleBindingsForBuildStage() {
             CredentialsPlugin.withBuildCredentials("credentials1")
             CredentialsPlugin.withBuildCredentials("credentials2")
 
-            def buildCredentials = CredentialsPlugin.getBuildCredentials()
-            assertThat(buildCredentials, hasSize(2))
+            def bindings = CredentialsPlugin.getBindings()
+            assertThat(bindings, hasSize(2))
         }
     }
 

--- a/test/CredentialsPluginTest.groovy
+++ b/test/CredentialsPluginTest.groovy
@@ -48,7 +48,7 @@ class CredentialsPluginTest {
     @Nested
     public class WithBuildCredentials {
         @Test
-        void addsUsernamePasswordBindingForBuildStage() {
+        void addsUsernamePasswordBinding() {
             CredentialsPlugin.withBuildCredentials("credentials1")
 
             def bindings = CredentialsPlugin.getBindings()
@@ -56,7 +56,7 @@ class CredentialsPluginTest {
         }
 
         @Test
-        void addsMultipleBindingsForBuildStage() {
+        void addsMultipleBindings() {
             CredentialsPlugin.withBuildCredentials("credentials1")
             CredentialsPlugin.withBuildCredentials("credentials2")
 

--- a/test/CredentialsPluginTest.groovy
+++ b/test/CredentialsPluginTest.groovy
@@ -46,6 +46,32 @@ class CredentialsPluginTest {
     }
 
     @Nested
+    public class WithBinding {
+        @Test
+        void addsABinding() {
+            def binding = { usernameColonPassword(credentialsId: 'my-user-colon-pass', variable: 'USERPASS') }
+            CredentialsPlugin.withBinding(binding)
+
+            def bindings = CredentialsPlugin.getBindings()
+            assertThat(bindings, hasItem(binding))
+        }
+
+        @Test
+        void addsMultipleBindingsIfCalledAgain() {
+            def binding1 = { string(credentialsId: 'my-token', variable: 'TOKEN') }
+            def binding2 = { usernamePassword(credentialsId: 'my-user-pass', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD') }
+
+            CredentialsPlugin.withBinding(binding1)
+            CredentialsPlugin.withBinding(binding2)
+
+            def bindings = CredentialsPlugin.getBindings()
+            assertThat(bindings.size(), equalTo(2))
+            assertThat(bindings, hasItem(binding1))
+            assertThat(bindings, hasItem(binding2))
+        }
+    }
+
+    @Nested
     public class WithBuildCredentials {
         @Test
         void addsUsernamePasswordBinding() {

--- a/test/MockWorkflowScript.groovy
+++ b/test/MockWorkflowScript.groovy
@@ -80,5 +80,11 @@ class MockWorkflowScript {
         closure.delegate = this
         closure()
     }
+
+    public withCredentials(bindings, Closure closure) {
+        print "MockworkflowScript.withCredentials(${bindings})"
+        closure.delegate = this
+        closure()
+    }
 }
 


### PR DESCRIPTION
CredentialsPlugin currently only supports username/password, but there are many more.  Support all types of credential bindings.

## Merge Checklist

* [x] Have you linked this Pull Request to an [Issue](https://github.com/manheim/terraform-pipeline/issues)?
* [x] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [x] Have you added relevant test cases for your change?
* [x] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [x] Have you updated the [CHANGELOG](https://github.com/manheim/terraform-pipeline/blob/master/CHANGELOG.md)?
