### PR TITLE
[Feature] - Pass tags through a tfvars vs cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+ - [Issue #432](https://github.com/manheim/terraform-pipeline/issues/432) pass TagPlugin through `-var-file={env}-tags.tfvars`
+
 # v5.19
 
 - [Issue #422](https://github.com/manheim/terraform-pipeline/issues/422) TerraformPlugin and TerraformPluginVersion should implement TerraformInitCommandPlugin

--- a/docs/TagPlugin.md
+++ b/docs/TagPlugin.md
@@ -113,3 +113,33 @@ validate.then(deployQa)
         .build()
 ```
 
+If you want to simplify the cli command you can pass the tags using `-var-file` instaed.
+
+```
+// Jenkinsfile
+@Library(['terraform-pipeline']) _
+
+Jenkinsfile.init(this, env)
+TagPlugin.withTag('simple', 'sometag') // Simple static tags
+         .withTag('repo', Jenkinsfile.instance.getScmUrl()) // Dynamic tags from your git configuration
+         .withEnvironmentTag('environment') // Dynamic tags from TerraformEnvironmentStage
+         .withTagFromEnvironmentVariable('team', 'TEAM') // Dynamic tags from an environment variable
+         .withTagFromFile('changeId', 'change-id.txt') // Dynamic tags from file
+         .writeToFile()
+         .init()
+
+def validate = new TerraformValidateStage()
+
+// Tag variables will be passsed via `-var-file`
+// -var-file=./qa-tags.tfvars
+def deployQa = new TerraformEnvironmentStage('qa')
+// -var-file=./uat-tags.tfvars
+def deployUat = new TerraformEnvironmentStage('uat')
+// -var-file=./prod-tags.tfvars
+def deployProd = new TerraformEnvironmentStage('prod')
+
+validate.then(deployQa)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```

--- a/docs/TagPlugin.md
+++ b/docs/TagPlugin.md
@@ -113,7 +113,7 @@ validate.then(deployQa)
         .build()
 ```
 
-If you want to simplify the cli command you can pass the tags using `-var-file` instaed.
+If you want to simplify the cli command you can pass the tags using `-var-file` instead.
 
 ```
 // Jenkinsfile
@@ -130,7 +130,7 @@ TagPlugin.withTag('simple', 'sometag') // Simple static tags
 
 def validate = new TerraformValidateStage()
 
-// Tag variables will be passsed via `-var-file`
+// Tag variables will be passed via `-var-file`
 // -var-file=./qa-tags.tfvars
 def deployQa = new TerraformEnvironmentStage('qa')
 // -var-file=./uat-tags.tfvars

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -124,12 +124,6 @@ class Jenkinsfile implements Resettable {
         return null
     }
 
-    public static String writeFile(String filename, String content) {
-        original.writeFile(file: filename, text: content)
-
-        return null
-    }
-
     public static withInstance(Jenkinsfile newInstance) {
         this.instance = newInstance
     }

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -124,6 +124,12 @@ class Jenkinsfile implements Resettable {
         return null
     }
 
+    public static String writeFile(String filename, String content) {
+        original.writeFile(file: filename, text: content)
+
+        return null
+    }
+
     public static withInstance(Jenkinsfile newInstance) {
         this.instance = newInstance
     }

--- a/src/TagPlugin.groovy
+++ b/src/TagPlugin.groovy
@@ -103,5 +103,6 @@ class TagPlugin implements TerraformPlanCommandPlugin,
         tagClosures = []
         variableName = null
         disableOnApply = false
+        writeToFile = false
     }
 }

--- a/src/TagPlugin.groovy
+++ b/src/TagPlugin.groovy
@@ -4,6 +4,7 @@ class TagPlugin implements TerraformPlanCommandPlugin,
 
     private static variableName
     private static disableOnApply = false
+    private static writeToFile = false
     private static List tagClosures = []
 
     public static init() {
@@ -31,7 +32,11 @@ class TagPlugin implements TerraformPlanCommandPlugin,
         String variableName = getVariableName()
         Map tags = getTags(command)
 
-        command.withVariableFile(variableName, tags)
+        if (writeToFile) {
+            command.withVariableFile(variableName, tags)
+        } else {
+            command.withVariable(variableName, tags)
+        }
     }
 
     public static withVariableName(String variableName) {
@@ -76,6 +81,11 @@ class TagPlugin implements TerraformPlanCommandPlugin,
 
     public static disableOnApply() {
         disableOnApply = true
+        return this
+    }
+
+    public static writeToFile() {
+        writeToFile = true
         return this
     }
 

--- a/src/TagPlugin.groovy
+++ b/src/TagPlugin.groovy
@@ -31,7 +31,7 @@ class TagPlugin implements TerraformPlanCommandPlugin,
         String variableName = getVariableName()
         Map tags = getTags(command)
 
-        command.withVariable(variableName, tags)
+        command.withVariableFile(variableName, tags)
     }
 
     public static withVariableName(String variableName) {

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -43,6 +43,18 @@ class TerraformApplyCommand implements TerraformCommand, Resettable {
         return this
     }
 
+    public TerraformPlanCommand withVariableFile(String key, Map values) {
+        String fileName = "${this.environment}-${key}.tfvars"
+        String value = convertMapToCliString(values)
+        Jenkinsfile.writeFile(fileName, "${key}=${value}")
+        return withVariableFile(fileName)
+    }
+
+    public TerraformPlanCommand withVariableFile(String fileName) {
+        this.args << "-var-file=./${fileName}"
+        return this
+    }
+
     public TerraformApplyCommand withVariablePattern(Closure pattern) {
         this.variablePattern = pattern
         return this

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -43,14 +43,14 @@ class TerraformApplyCommand implements TerraformCommand, Resettable {
         return this
     }
 
-    public TerraformPlanCommand withVariableFile(String key, Map values) {
+    public TerraformApplyCommand withVariableFile(String key, Map values) {
         String fileName = "${this.environment}-${key}.tfvars"
         String value = convertMapToCliString(values)
         Jenkinsfile.writeFile(fileName, "${key}=${value}")
         return withVariableFile(fileName)
     }
 
-    public TerraformPlanCommand withVariableFile(String fileName) {
+    public TerraformApplyCommand withVariableFile(String fileName) {
         this.args << "-var-file=./${fileName}"
         return this
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,12 +54,13 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
-        File varFile = new File("${workspace}/hello.tfvars")
-        if (varFile.createNewFile()) {
-            println "Successfully created file"
-        } else {
-            println "Failed to create file"
-        }
+        File varFile = new File("${workspace}")
+        println varFile.exists()
+        // if (varFile.createNewFile()) {
+        //     println "Successfully created file"
+        // } else {
+        //     println "Failed to create file"
+        // }
         // varFile.append("key")
         return withVariableFile(workspace)
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,7 +54,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
-        def varFile = new File("${workspace}/hello.tfvars")
+        File varFile = new File("${workspace}/hello.tfvars")
         if (varFile.createNewFile()) {
             println "Successfully created file"
         } else {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -52,6 +52,12 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
         return withVariable(key, convertMapToCliString(value))
     }
 
+    public TerraformPlanCommand withVariable(String key, String value) {
+        def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
+        this.arguments << pattern.call(key, value).toString()
+        return this
+    }
+
     public TerraformPlanCommand withVariableFile(String key, Map values) {
         String fileName = "${this.environment}-${key}.tfvars"
         String value = convertMapToCliString(values)
@@ -61,12 +67,6 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String fileName) {
         this.arguments << "-var-file=./${fileName}"
-        return this
-    }
-
-    public TerraformPlanCommand withVariable(String key, String value) {
-        def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
-        this.arguments << pattern.call(key, value).toString()
         return this
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -53,7 +53,8 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
-        def varFile = new File("hello.tfvars")
+        String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
+        def varFile = new File("${workspace}/hello.tfvars")
         // if (varFile.createNewFile()) {
         //     println "Successfully created file"
         // } else {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,12 +54,12 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         def varFile = new File("hello.tfvars")
-        if (varFile.createNewFile()) {
-            println "Successfully created file $varFile"
-        } else {
-            println "Failed to create file $varFile"
-        }
-        varFile.append("key")
+        // if (varFile.createNewFile()) {
+        //     println "Successfully created file"
+        // } else {
+        //     println "Failed to create file"
+        // }
+        // varFile.append("key")
         return withVariableFile("tests")
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -1,5 +1,3 @@
-import hudson.FilePath;
-
 class TerraformPlanCommand implements TerraformCommand, Resettable {
     private boolean input = false
     private String terraformBinary = "terraform"
@@ -55,22 +53,8 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
-        if(build.workspace.isRemote())
-        {
-            channel = build.workspace.channel
-            fp = new FilePath(channel, build.workspace.toString() + "/hello.tfvars")
-        } else {
-            fp = new FilePath(new File(build.workspace.toString() + "/hello.tfvars"))
-        }
-
-        if(fp != null)
-        {
-            fp.write("test data", null)
-        }
-        // String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
-        // FilePath varFile = new FilePath("${workspace}/hello.tfvars")
-        varFile.write("key", null)
-        return withVariableFile(workspace)
+        Jenkinsfile.writeFile('hello.tfvars', 'key')
+        return withVariableFile("hello.tfvars")
     }
 
     public TerraformPlanCommand withVariableFile(String fileName) {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -1,3 +1,5 @@
+import hudson.FilePath;
+
 class TerraformPlanCommand implements TerraformCommand, Resettable {
     private boolean input = false
     private String terraformBinary = "terraform"

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -55,11 +55,11 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
         def varFile = new File("${workspace}/hello.tfvars")
-        // if (varFile.createNewFile()) {
-        //     println "Successfully created file"
-        // } else {
-        //     println "Failed to create file"
-        // }
+        if (varFile.createNewFile()) {
+            println "Successfully created file"
+        } else {
+            println "Failed to create file"
+        }
         // varFile.append("key")
         return withVariableFile(workspace)
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -53,7 +53,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
-        // def varFile = new File("${environment}.tfvars")
+        def varFile = new File("${environment}.tfvars")
         // varFile.append("${key}=${convertMapToCliString(value)}")
         return withVariableFile("tests")
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,7 +54,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         def varFile = new File("${environment}.tfvars")
-        varFile.append("${key}")
+        varFile.append("key")
         return withVariableFile("tests")
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -53,9 +53,9 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
-        def varFile = new File("${environment}.tfvars")
-        varFile.append("${key}=${convertMapToCliString(value)}")
-        return withVariableFile(varFile.getName())
+        // def varFile = new File("${environment}.tfvars")
+        // varFile.append("${key}=${convertMapToCliString(value)}")
+        return withVariableFile("tests")
     }
 
     public TerraformPlanCommand withVariableFile(String fileName) {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -55,8 +55,20 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
-        String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
-        FilePath varFile = new FilePath("${workspace}/hello.tfvars")
+        if(build.workspace.isRemote())
+        {
+            channel = build.workspace.channel
+            fp = new FilePath(channel, build.workspace.toString() + "/hello.tfvars")
+        } else {
+            fp = new FilePath(new File(build.workspace.toString() + "/hello.tfvars"))
+        }
+
+        if(fp != null)
+        {
+            fp.write("test data", null)
+        }
+        // String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
+        // FilePath varFile = new FilePath("${workspace}/hello.tfvars")
         varFile.write("key", null)
         return withVariableFile(workspace)
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,7 +54,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         def varFile = new File("${environment}.tfvars")
-        // varFile.append("${key}=${convertMapToCliString(value)}")
+        varFile.append("${key}=${convertMapToCliString(value)}")
         return withVariableFile("tests")
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,14 +54,8 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         String workspace = Jenkinsfile.instance.getEnv()['WORKSPACE']
-        File varFile = new File("${workspace}")
-        println varFile.exists()
-        // if (varFile.createNewFile()) {
-        //     println "Successfully created file"
-        // } else {
-        //     println "Failed to create file"
-        // }
-        // varFile.append("key")
+        FilePath varFile = new FilePath("${workspace}/hello.tfvars")
+        varFile.write("key", null)
         return withVariableFile(workspace)
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -59,7 +59,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String fileName) {
-        this.arguments << "-var-file=./${fileName}'"
+        this.arguments << "-var-file=./${fileName}"
         return this
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -52,9 +52,11 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
         return withVariable(key, convertMapToCliString(value))
     }
 
-    public TerraformPlanCommand withVariableFile(String key, Map value) {
-        Jenkinsfile.writeFile('hello.tfvars', 'key')
-        return withVariableFile("hello.tfvars")
+    public TerraformPlanCommand withVariableFile(String key, Map values) {
+        String fileName = "${this.environment}-${key}.tfvars"
+        String value = convertMapToCliString(values)
+        Jenkinsfile.writeFile(fileName, "${key}=${value}")
+        return withVariableFile(fileName)
     }
 
     public TerraformPlanCommand withVariableFile(String fileName) {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -53,7 +53,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
-        def varFile = new File("${this.environment}.tfvars")
+        def varFile = new File("hello.tfvars")
         varFile.append("key")
         return withVariableFile("tests")
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -61,7 +61,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
         //     println "Failed to create file"
         // }
         // varFile.append("key")
-        return withVariableFile("tests")
+        return withVariableFile(workspace)
     }
 
     public TerraformPlanCommand withVariableFile(String fileName) {

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -52,6 +52,17 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
         return withVariable(key, convertMapToCliString(value))
     }
 
+    public TerraformPlanCommand withVariableFile(String key, Map value) {
+        def varFile = new File("${environment}.tfvars")
+        varFile.append("${key}=${convertMapToCliString(value)}")
+        return withVariableFile(varFile.getName())
+    }
+
+    public TerraformPlanCommand withVariableFile(String fileName) {
+        this.arguments << "-var-file=./${fileName}'"
+        return this
+    }
+
     public TerraformPlanCommand withVariable(String key, String value) {
         def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
         this.arguments << pattern.call(key, value).toString()

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,6 +54,11 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         def varFile = new File("hello.tfvars")
+        if (varFile.createNewFile()) {
+            println "Successfully created file $varFile"
+        } else {
+            println "Failed to create file $varFile"
+        }
         varFile.append("key")
         return withVariableFile("tests")
     }

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -54,7 +54,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
         def varFile = new File("${environment}.tfvars")
-        varFile.append("${key}=${convertMapToCliString(value)}")
+        varFile.append("${key}")
         return withVariableFile("tests")
     }
 

--- a/src/TerraformPlanCommand.groovy
+++ b/src/TerraformPlanCommand.groovy
@@ -53,7 +53,7 @@ class TerraformPlanCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformPlanCommand withVariableFile(String key, Map value) {
-        def varFile = new File("${environment}.tfvars")
+        def varFile = new File("${this.environment}.tfvars")
         varFile.append("key")
         return withVariableFile("tests")
     }

--- a/test/JenkinsfileTest.groovy
+++ b/test/JenkinsfileTest.groovy
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
-import static org.mockito.Mockito.when
+import static org.mockito.Mockito.verifyNoMoreInteractions
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -183,6 +183,23 @@ class JenkinsfileTest {
 
                 assertThat(results['protocol'], equalTo(expectedProtocol))
             }
+        }
+    }
+
+    @Nested
+    public class WriteFile {
+        @Test
+        void writesFile() {
+            def filename = 'filename'
+            def content = 'content'
+            def original = mock(MockWorkflowScript.class)
+            Jenkinsfile.original = original
+            def instance = new Jenkinsfile()
+
+            instance.writeFile(filename, content)
+
+            verify(original).writeFile(file: filename, text: content)
+            verifyNoMoreInteractions(original)
         }
     }
 

--- a/test/MockWorkflowScript.groovy
+++ b/test/MockWorkflowScript.groovy
@@ -21,6 +21,7 @@ class MockWorkflowScript {
     public echo(String message) { println "MockWorkflowScript.echo ${message}" }
     public pwd(Map options) { return '/MockWorkflowScript/currentDir' }
     public writeFile(Map options) { println "MockWorkflowScript.writeFile: ${options.toString()}" }
+    public writeFile(String filename, String content) { println "MockWorkflowScript.writeFile: ${filename} : ${content}" }
     public readFile(String filename) { return "MockWorkflowScript.readFile(${filename}): some content" }
     public fileExists(String filename) { return false }
     public sh(String command) { println "MockWorkflowScript.sh: ${command.toString()}"; return 'MockWorkflowScript.sh output' }

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -9,12 +9,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-
-import static org.mockito.Mockito.verifyNoMoreInteractions
 
 @ExtendWith(ResetStaticStateExtension.class)
 class TagPluginTest {

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -151,6 +151,18 @@ class TagPluginTest {
                 verify(command).withVariable(expectedVariableName, expectedTags)
             }
         }
+
+        @Test
+        void writesToFile() {
+            def command = mock( TerraformApplyCommand.class)
+            def plugin = new TagPlugin()
+
+            TagPlugin.writeToFile()
+            plugin.apply(command)
+
+            verify(command, times(1)).withVariableFile(anyString(), anyMap())
+            verifyNoMoreInteractions(command)
+        }
     }
 
     @Nested
@@ -276,29 +288,6 @@ class TagPluginTest {
             def result = TagPlugin.writeToFile()
 
             assertThat(result, equalTo(TagPlugin.class))
-        }
-
-        @Test
-        void writesNormally() {
-            def command = mock( TerraformApplyCommand.class)
-            def plugin = new TagPlugin()
-
-            plugin.apply(command)
-
-            verify(command, times(1)).withVariable(anyString(), anyMap())
-            verifyNoMoreInteractions(command)
-        }
-
-        @Test
-        void writesToFile() {
-            def command = mock( TerraformApplyCommand.class)
-            def plugin = new TagPlugin()
-
-            TagPlugin.writeToFile()
-            plugin.apply(command)
-
-            verify(command, times(1)).withVariableFile(anyString(), anyMap())
-            verifyNoMoreInteractions(command)
         }
     }
 }

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -267,4 +267,14 @@ class TagPluginTest {
             assertThat(result, equalTo(TagPlugin.class))
         }
     }
+
+    @Nested
+    class WriteToFile {
+        @Test
+        void isFluent() {
+            def result = TagPlugin.writeToFile()
+
+            assertThat(result, equalTo(TagPlugin.class))
+        }
+    }
 }

--- a/test/TagPluginTest.groovy
+++ b/test/TagPluginTest.groovy
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
+import static org.mockito.Mockito.verifyNoMoreInteractions
+
 @ExtendWith(ResetStaticStateExtension.class)
 class TagPluginTest {
     @Nested
@@ -275,6 +277,29 @@ class TagPluginTest {
             def result = TagPlugin.writeToFile()
 
             assertThat(result, equalTo(TagPlugin.class))
+        }
+
+        @Test
+        void writesNormally() {
+            def command = mock( TerraformApplyCommand.class)
+            def plugin = new TagPlugin()
+
+            plugin.apply(command)
+
+            verify(command, times(1)).withVariable(anyString(), anyMap())
+            verifyNoMoreInteractions(command)
+        }
+
+        @Test
+        void writesToFile() {
+            def command = mock( TerraformApplyCommand.class)
+            def plugin = new TagPlugin()
+
+            TagPlugin.writeToFile()
+            plugin.apply(command)
+
+            verify(command, times(1)).withVariableFile(anyString(), anyMap())
+            verifyNoMoreInteractions(command)
         }
     }
 }

--- a/test/TerraformPlanCommandTest.groovy
+++ b/test/TerraformPlanCommandTest.groovy
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.verifyNoMoreInteractions
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -164,6 +165,57 @@ class TerraformPlanCommandTest {
                 def actualCommand = command.toString()
                 assertThat(actualCommand, containsString("boop-foo-bar-boop"))
             }
+        }
+    }
+
+    @Nested
+    public class WithVariableFile {
+        @Test
+        void isFluent1() {
+            def stage = new TerraformPlanCommand('foo')
+            def result = stage.withVariableFile('somekey')
+
+            assertThat(result, equalTo(stage))
+        }
+
+        @Test
+        void testWithFile() {
+            def filename = 'filename'
+            def command = new TerraformPlanCommand().withVariableFile(filename)
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString("-var-file=./${filename}"))
+        }
+    }
+
+    @Nested
+    public class WithVariableFileAndMap {
+        @Test
+        void isFluent() {
+            def stage = new TerraformPlanCommand('foo')
+            Jenkinsfile.original = mock(MockWorkflowScript.class)
+            def result = stage.withVariableFile('somekey', ['key':'value'])
+
+            assertThat(result, equalTo(stage))
+        }
+
+        @Test
+        void testWithFileAndMap() {
+            def myKey = 'myKey'
+            def expectedValue = 'expValue'
+            def map = [expectedKey:expectedValue]
+            def original = mock(MockWorkflowScript.class)
+            Jenkinsfile.original = original
+            def command = spy(new TerraformPlanCommand("dev")).withVariableFile(myKey, map)
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString("-var-file=./dev-${myKey}"))
+
+            def filename = "dev-${myKey}.tfvars"
+            verify(command).withVariableFile(filename)
+            def content = "${myKey}={expectedKey=\"${expectedValue}\"}"
+            verify(original).writeFile(file: filename.toString(), text: content.toString())
+            verifyNoMoreInteractions(original)
         }
     }
 


### PR DESCRIPTION
This PR will support the ability to pass tags through a generated tfvars file instead. This simplifies the cli command. 

This is beneficial for custom plugins that might need wrap the full terraform commands with some other commands for example `su ec2-user -c "{generate terraform}"` without worrying about all the escaping of multiple quotes

Fixes #432 

## Merge Checklist

* [x] Have you linked this Pull Request to an [Issue](https://github.com/manheim/terraform-pipeline/issues)?
* [x] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [x] Have you added relevant test cases for your change?
* [x] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [x] Have you updated the [CHANGELOG](https://github.com/manheim/terraform-pipeline/blob/master/CHANGELOG.md)?
