### PR TITLE
[Bugfix] Fixes #417 - Force terraform command to `apply` if a plan file is being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
- - [Issue #432](https://github.com/manheim/terraform-pipeline/issues/432) pass TagPlugin through `-var-file={env}-tags.tfvars`
+- [Issue #432](https://github.com/manheim/terraform-pipeline/issues/432) pass TagPlugin through `-var-file={env}-tags.tfvars`
+- [Issue #417](https://github.com/manheim/terraform-pipeline/issues/417) DestroyPlugin & PassPlanFilePlugin - Terraform Destroy can't be called with a plan file
 
 # v5.19
 

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -107,7 +107,14 @@ class TerraformApplyCommand implements TerraformCommand, Resettable {
         if (directory && chdir_flag) {
             pieces << "-chdir=${directory}"
         }
-        pieces << command
+        // If we have a plan file, apply is the only command that works.
+        // Even on destroy, you must use `terraform apply` for a plan file
+        // created with the `-destroy` argument.
+        if (planFile) {
+            pieces << "apply"
+        } else {
+            pieces << command
+        }
         if (!input) {
             pieces << "-input=false"
         }

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -236,6 +236,15 @@ class TerraformApplyCommandTest {
             def actualCommand = command.toString()
             assertThat(actualCommand, endsWith(" foobar"))
         }
+
+        @Test
+        void forcesApplyIfPlanFilePresent() {
+            def command = new TerraformApplyCommand().withPlanFile("foobar")
+                                                     .withCommand("destroy")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, startsWith("terraform apply"))
+        }
     }
 
     @Nested


### PR DESCRIPTION
If a plan file is being used in the `TerraformApplyCommand`, then the only
applicable Terraform subcommand is `apply`. This PR forces apply to be used if
a plan file is set. This works whether the plan file was created with or without
the `-destroy` argument.

- Force the use of `terraform apply` in TerraformApplyCommand if a planFile is present
- Update changelog

## Merge Checklist

* [x] Have you linked this Pull Request to an [Issue](https://github.com/manheim/terraform-pipeline/issues)?
* [x] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [x] Have you added relevant test cases for your change?
* [x] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [x] Have you updated the [CHANGELOG](https://github.com/manheim/terraform-pipeline/blob/master/CHANGELOG.md)?
