### PR TITLE
Fixes #436 - Omit variables and variable files from apply command when using a plan file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build
 .idea
 *.iml
 /out
+.history
+.vscode
+bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Issue #432](https://github.com/manheim/terraform-pipeline/issues/432) pass TagPlugin through `-var-file={env}-tags.tfvars`
 - [Issue #417](https://github.com/manheim/terraform-pipeline/issues/417) DestroyPlugin & PassPlanFilePlugin - Terraform Destroy can't be called with a plan file
+- [Issue #436](https://github.com/manheim/terraform-pipeline/issues/436) Bug Fix: Omit variables and variable files from apply command if a plan file is specified
 
 # v5.19
 

--- a/src/TerraformApplyCommand.groovy
+++ b/src/TerraformApplyCommand.groovy
@@ -6,6 +6,7 @@ class TerraformApplyCommand implements TerraformCommand, Resettable {
     private prefixes = []
     private suffixes = []
     private args = []
+    private vars = []
     private String directory
     private String planFile
     private boolean chdir_flag = false
@@ -39,7 +40,7 @@ class TerraformApplyCommand implements TerraformCommand, Resettable {
 
     public TerraformApplyCommand withVariable(String key, String value) {
         def pattern = variablePattern ?: { myKey, myValue -> "-var '${myKey}=${myValue}'" }
-        this.args << pattern.call(key, value).toString()
+        this.vars << pattern.call(key, value).toString()
         return this
     }
 
@@ -51,7 +52,7 @@ class TerraformApplyCommand implements TerraformCommand, Resettable {
     }
 
     public TerraformApplyCommand withVariableFile(String fileName) {
-        this.args << "-var-file=./${fileName}"
+        this.vars << "-var-file=./${fileName}"
         return this
     }
 
@@ -119,6 +120,11 @@ class TerraformApplyCommand implements TerraformCommand, Resettable {
             pieces << "-input=false"
         }
         pieces += args
+        // If we have a plan file, we cannot pass vars, they're already
+        // baked into the plan.
+        if (!planFile) {
+            pieces += vars
+        }
         if (directory && !chdir_flag && !planFile) {
             pieces << directory
         }

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -245,6 +245,17 @@ class TerraformApplyCommandTest {
             def actualCommand = command.toString()
             assertThat(actualCommand, startsWith("terraform apply"))
         }
+
+        @Test
+        void ignoresVarsIfPlanFilePresent() {
+            def command = new TerraformApplyCommand().withPlanFile("foobar")
+                                                     .withVariable("foo", "bar")
+                                                     .withVariableFile("varfile")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, not(containsString("-var")))
+            assertThat(actualCommand, not(containsString("-var-file")))
+        }
     }
 
     @Nested

--- a/test/TerraformApplyCommandTest.groovy
+++ b/test/TerraformApplyCommandTest.groovy
@@ -256,6 +256,16 @@ class TerraformApplyCommandTest {
             assertThat(actualCommand, not(containsString("-var")))
             assertThat(actualCommand, not(containsString("-var-file")))
         }
+
+        @Test
+        void usesVarsIfPlanFileNotPresent() {
+            def command = new TerraformApplyCommand().withVariable("foo", "bar")
+                                                     .withVariableFile("varfile")
+
+            def actualCommand = command.toString()
+            assertThat(actualCommand, containsString("-var"))
+            assertThat(actualCommand, containsString("-var-file"))
+        }
     }
 
     @Nested


### PR DESCRIPTION
- Omit variables and variable files when building apply command and a plan file has been specified

## Merge Checklist

* [x] Have you linked this Pull Request to an [Issue](https://github.com/manheim/terraform-pipeline/issues)?
* [x] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [x] Have you added relevant test cases for your change?
* [x] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [x] Have you updated the [CHANGELOG](https://github.com/manheim/terraform-pipeline/blob/master/CHANGELOG.md)?
