### PR TITLE
Fixes #444 - Add duration parameter to WithAwsPlugin.withRole()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Issue #432](https://github.com/manheim/terraform-pipeline/issues/432) pass TagPlugin through `-var-file={env}-tags.tfvars`
 - [Issue #417](https://github.com/manheim/terraform-pipeline/issues/417) DestroyPlugin & PassPlanFilePlugin - Terraform Destroy can't be called with a plan file
 - [Issue #436](https://github.com/manheim/terraform-pipeline/issues/436) Bug Fix: Omit variables and variable files from apply command if a plan file is specified
+- [Issue #444](https://github.com/manheim/terraform-pipeline/issues/444) Expose optional duration parameter on WithAwsPlugin's `withRole()`
 
 # v5.19
 

--- a/docs/WithAwsPlugin.md
+++ b/docs/WithAwsPlugin.md
@@ -61,8 +61,14 @@ validate.then(deployQa)
         .build()
 ```
 
-If you want to specify a role session duration other than the default of 1 hour (3600 seconds), you can do so by providing an integer `duration` parameter to the `withRole()` call, like:
+If you want to specify a role session duration other than the default of 1 hour (3600 seconds), you can do so by providing an integer `duration` parameter to the `withRole()` call. You _must_ specify the Role ARN in this case, even if `null`. i.e.:
 
 ```
-WithAwsPlugin.withRole(duration: 43200).init()
+WithAwsPlugin.withRole('MY_ROLE_ARN', 43200).init()
+```
+
+or, to use the default environment variables for the role ARN:
+
+```
+WithAwsPlugin.withRole(null, 43200).init()
 ```

--- a/docs/WithAwsPlugin.md
+++ b/docs/WithAwsPlugin.md
@@ -60,3 +60,9 @@ validate.then(deployQa)
         .then(deployProd)
         .build()
 ```
+
+If you want to specify a role session duration other than the default of 1 hour (3600 seconds), you can do so by providing an integer `duration` parameter to the `withRole()` call, like:
+
+```
+WithAwsPlugin.withRole(duration: 43200).init()
+```

--- a/docs/WithAwsPlugin.md
+++ b/docs/WithAwsPlugin.md
@@ -61,14 +61,14 @@ validate.then(deployQa)
         .build()
 ```
 
-If you want to specify a role session duration other than the default of 1 hour (3600 seconds), you can do so by providing an integer `duration` parameter to the `withRole()` call. You _must_ specify the Role ARN in this case, even if `null`. i.e.:
+If you want to specify a role session duration other than the default of 1 hour (3600 seconds), you can do so by providing an integer duration to `withDuration()`:
 
 ```
-WithAwsPlugin.withRole('MY_ROLE_ARN', 43200).init()
+WithAwsPlugin.withDuration(43200).init()
 ```
 
-or, to use the default environment variables for the role ARN:
+or, with a specific role ARN
 
 ```
-WithAwsPlugin.withRole(null, 43200).init()
+WithAwsPlugin.withRole('MY_ROLE_ARN').withDuration(43200).init()
 ```

--- a/src/WithAwsPlugin.groovy
+++ b/src/WithAwsPlugin.groovy
@@ -20,7 +20,7 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     public Closure addWithAwsRole(String environment) {
         return { closure ->
             String iamRole = getRole(environment)
-            Integer sessionDuration = this.duration
+            Integer sessionDuration = getDuration()
 
             if (iamRole != null) {
                 withAWS(role: iamRole, duration: sessionDuration) {
@@ -57,6 +57,10 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
         }
 
         return tempRole
+    }
+
+    public Integer getDuration() {
+        return this.@duration
     }
 
     public static void reset() {

--- a/src/WithAwsPlugin.groovy
+++ b/src/WithAwsPlugin.groovy
@@ -2,6 +2,7 @@ import static TerraformEnvironmentStage.ALL
 
 class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     private static role
+    private static duration
 
     public static void init() {
         WithAwsPlugin plugin = new WithAwsPlugin()
@@ -19,9 +20,10 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     public Closure addWithAwsRole(String environment) {
         return { closure ->
             String iamRole = getRole(environment)
+            Integer sessionDuration = getDuration()
 
             if (iamRole != null) {
-                withAWS(role: iamRole) {
+                withAWS(role: iamRole, duration: sessionDuration) {
                     sh "echo Running AWS commands under the role: ${iamRole}"
                     closure()
                 }
@@ -32,8 +34,9 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
         }
     }
 
-    public static withRole(String role = null) {
+    public static withRole(String role = null, Integer duration = 3600) {
         this.role = role
+        this.duration = duration
 
         return this
     }
@@ -56,7 +59,12 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
         return tempRole
     }
 
+    public Integer getDuration() {
+        return this.duration
+    }
+
     public static void reset() {
         this.role = null
+        this.duration = 3600
     }
 }

--- a/src/WithAwsPlugin.groovy
+++ b/src/WithAwsPlugin.groovy
@@ -20,7 +20,7 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     public Closure addWithAwsRole(String environment) {
         return { closure ->
             String iamRole = getRole(environment)
-            Integer sessionDuration = getDuration()
+            Integer sessionDuration = this.duration
 
             if (iamRole != null) {
                 withAWS(role: iamRole, duration: sessionDuration) {
@@ -57,10 +57,6 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
         }
 
         return tempRole
-    }
-
-    public Integer getDuration() {
-        return this.duration
     }
 
     public static void reset() {

--- a/src/WithAwsPlugin.groovy
+++ b/src/WithAwsPlugin.groovy
@@ -34,8 +34,13 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
         }
     }
 
-    public static withRole(String role = null, Integer duration = 3600) {
+    public static withRole(String role = null) {
         this.role = role
+
+        return this
+    }
+
+    public static withDuration(Integer duration = 3600) {
         this.duration = duration
 
         return this
@@ -60,7 +65,13 @@ class WithAwsPlugin implements TerraformEnvironmentStagePlugin, Resettable {
     }
 
     public Integer getDuration() {
-        return this.@duration
+        def tempDuration = this.@duration
+
+        if (tempDuration == null) {
+            tempDuration = 3600
+        }
+
+        return tempDuration
     }
 
     public static void reset() {

--- a/test/WithAwsPluginTest.groovy
+++ b/test/WithAwsPluginTest.groovy
@@ -85,44 +85,32 @@ class WithAwsPluginTest {
     }
 
     @Nested
-    public class WithExplicitRole {
+    public class WithDefaultDuration {
         @Test
-        void returnsProvidedRole() {
-            def expectedRole = "myRole"
+        void returnsDefaultDuration() {
+            def expectedDuration = 3600
             def plugin = new WithAwsPlugin()
+            MockJenkinsfile.withEnv(AWS_ROLE_ARN: 'foo')
 
-            plugin.withRole(expectedRole)
+            plugin.withRole()
 
-            def actualRole = plugin.getRole()
-
-            assertThat(actualRole, is(expectedRole))
+            def actualDuration = plugin.getDuration()
+            assertThat(actualDuration, is(expectedDuration))
         }
+    }
 
+    @Nested
+    public class WithExplicitDuration {
         @Test
-        void prefersProvidedRoleOverGenericRole() {
-            def expectedRole = "correctRole"
+        void returnsExplicitDuration() {
+            def expectedDuration = 43200
             def plugin = new WithAwsPlugin()
-            MockJenkinsfile.withEnv(AWS_ROLE_ARN: 'incorrectRole')
 
-            plugin.withRole(expectedRole)
+            plugin.withRole(duration: expectedDuration)
 
-            def actualRole = plugin.getRole()
+            def actualDuration = plugin.getDuration()
 
-            assertThat(actualRole, is(expectedRole))
-        }
-
-        @Test
-        void prefersProvidedRoleOverEnvironmntSpecificRole() {
-            def expectedRole = "correctRole"
-            def plugin = new WithAwsPlugin()
-            MockJenkinsfile.withEnv(QA_AWS_ROLE_ARN: 'incorrectRole')
-
-            plugin.withRole(expectedRole)
-
-            def actualRole = plugin.getRole('qa')
-
-            assertThat(actualRole, is(expectedRole))
+            assertThat(actualDuration, is(expectedDuration))
         }
     }
 }
-

--- a/test/WithAwsPluginTest.groovy
+++ b/test/WithAwsPluginTest.groovy
@@ -106,7 +106,7 @@ class WithAwsPluginTest {
             def expectedDuration = 43200
             def plugin = new WithAwsPlugin()
 
-            plugin.withRole(duration: expectedDuration)
+            plugin.withRole(null, expectedDuration)
 
             def actualDuration = plugin.getDuration()
 

--- a/test/WithAwsPluginTest.groovy
+++ b/test/WithAwsPluginTest.groovy
@@ -92,8 +92,6 @@ class WithAwsPluginTest {
             def plugin = new WithAwsPlugin()
             MockJenkinsfile.withEnv(AWS_ROLE_ARN: 'foo')
 
-            plugin.withRole()
-
             def actualDuration = plugin.getDuration()
             assertThat(actualDuration, is(expectedDuration))
         }
@@ -106,7 +104,7 @@ class WithAwsPluginTest {
             def expectedDuration = 43200
             def plugin = new WithAwsPlugin()
 
-            plugin.withRole(null, expectedDuration)
+            plugin.withDuration(expectedDuration)
 
             def actualDuration = plugin.getDuration()
 


### PR DESCRIPTION
Work in progress PR to fix #444 by adding an optional `duration` parameter to WithAwsPlugin.withRole().

## Merge Checklist

* [x] Have you linked this Pull Request to an [Issue](https://github.com/manheim/terraform-pipeline/issues)?
* [x] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [x] Have you added relevant test cases for your change?
* [x] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [x] Have you updated the [CHANGELOG](https://github.com/manheim/terraform-pipeline/blob/master/CHANGELOG.md)?
