### PR TITLE
adding unstash of artifacts to RergressionStage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [Issue #448](https://github.com/manheim/terraform-pipeline/issues/448) Added RegressionStage for unstashing of artifacts
+
 # v5.20.0
 
 - [Issue #372](https://github.com/manheim/terraform-pipeline/issues/372) Replace `master` branch with `main` in documentation

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -1,6 +1,6 @@
 import static TerraformEnvironmentStage.ALL
 
-class BuildStage implements Stage, DecoratableStage, TerraformEnvironmentStagePlugin, Resettable {
+class BuildStage implements Stage, DecoratableStage, TerraformEnvironmentStagePlugin, RegressionStagePlugin, Resettable {
     private final String ARTIFACT_STASH_KEY = 'buildArtifact'
 
     public String buildCommand

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -24,6 +24,7 @@ class BuildStage implements Stage, DecoratableStage, TerraformEnvironmentStagePl
     public BuildStage saveArtifact(String artifactIncludePattern) {
         this.artifactIncludePattern = artifactIncludePattern
         TerraformEnvironmentStage.addPlugin(this)
+        RegressionStage.addPlugin(this)
         return this
     }
 
@@ -37,6 +38,11 @@ class BuildStage implements Stage, DecoratableStage, TerraformEnvironmentStagePl
 
     @Override
     public void apply(TerraformEnvironmentStage stage) {
+        stage.decorate(ALL, unstashArtifact(ARTIFACT_STASH_KEY))
+    }
+
+    @Override
+    public void apply(RegressionStage stage) {
         stage.decorate(ALL, unstashArtifact(ARTIFACT_STASH_KEY))
     }
 

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -43,7 +43,7 @@ class BuildStage implements Stage, DecoratableStage, TerraformEnvironmentStagePl
 
     @Override
     public void apply(RegressionStage stage) {
-        stage.decorate(ALL, unstashArtifact(ARTIFACT_STASH_KEY))
+        stage.decorate(unstashArtifact(ARTIFACT_STASH_KEY))
     }
 
     private Closure unstashArtifact(String artifactStashKey) {

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -48,11 +48,14 @@ class BuildStage implements Stage, DecoratableStage, TerraformEnvironmentStagePl
 
     private Closure unstashArtifact(String artifactStashKey) {
         return { closure ->
+            sh "echo this is the directory before the unstash; ls -l"
             unstash "${artifactStashKey}"
+            sh "echo this is the directory after the unstash; ls -l"
             closure()
+            sh "echo this is the directory at the end of the unstashClosure; ls -l"
         }
     }
-
+  
     public void decorate(Closure decoration) {
         decorations.add(decoration)
     }


### PR DESCRIPTION
## Merge Checklist

* [X] Have you linked this Pull Request to an [Issue](https://github.com/manheim/terraform-pipeline/issues)?
* [ ] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [ ] Have you added relevant test cases for your change?
* [X] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [X] Have you updated the [CHANGELOG](https://github.com/manheim/terraform-pipeline/blob/master/CHANGELOG.md)?

## Description
Adding functionality to unstash build artifacts for any RegressionStage jobs

This addresses [Issue #448](https://github.com/manheim/terraform-pipeline/issues/448)

### Testing
This was tested on an internal facing Jenkins instance using a GHE repo. Not posting those details here since this public facing. 

### ./gradlew check --info output
```
CAI-P039022K7M:terraform-pipeline jared.bloomer$ ./gradlew check --info
Initialized native services in: /Users/jared.bloomer/.gradle/native
Found daemon DaemonInfo{pid=45180, address=[ec8f26e4-b13a-47a6-9045-714f5d11d15b port:50459, addresses:[/0:0:0:0:0:0:0:1, /127.0.0.1]], state=Idle, lastBusy=1697466009965, context=DefaultDaemonContext[uid=46cf1275-30b9-49a6-87b3-7041f935b5db,javaHome=/opt/homebrew/Cellar/openjdk/21/libexec/openjdk.jdk/Contents/Home,daemonRegistryDir=/Users/jared.bloomer/.gradle/daemon,pid=45180,idleTimeout=10800000,priority=NORMAL,daemonOpts=--add-opens,java.base/java.util=ALL-UNNAMED,--add-opens,java.base/java.lang=ALL-UNNAMED,--add-opens,java.base/java.lang.invoke=ALL-UNNAMED,--add-opens,java.prefs/java.util.prefs=ALL-UNNAMED,-XX:MaxMetaspaceSize=256m,-XX:+HeapDumpOnOutOfMemoryError,-Xmx512m,-Dfile.encoding=UTF-8,-Duser.country=US,-Duser.language=en,-Duser.variant]} however its context does not match the desired criteria.
Java home is different.
Wanted: DefaultDaemonContext[uid=null,javaHome=/opt/homebrew/Cellar/openjdk@11/11.0.20.1/libexec/openjdk.jdk/Contents/Home,daemonRegistryDir=/Users/jared.bloomer/.gradle/daemon,pid=50769,idleTimeout=null,priority=NORMAL,daemonOpts=--add-opens,java.base/java.util=ALL-UNNAMED,--add-opens,java.base/java.lang=ALL-UNNAMED,--add-opens,java.base/java.lang.invoke=ALL-UNNAMED,--add-opens,java.prefs/java.util.prefs=ALL-UNNAMED,-XX:MaxMetaspaceSize=256m,-XX:+HeapDumpOnOutOfMemoryError,-Xmx512m,-Dfile.encoding=UTF-8,-Duser.country=US,-Duser.language=en,-Duser.variant]
Actual: DefaultDaemonContext[uid=46cf1275-30b9-49a6-87b3-7041f935b5db,javaHome=/opt/homebrew/Cellar/openjdk/21/libexec/openjdk.jdk/Contents/Home,daemonRegistryDir=/Users/jared.bloomer/.gradle/daemon,pid=45180,idleTimeout=10800000,priority=NORMAL,daemonOpts=--add-opens,java.base/java.util=ALL-UNNAMED,--add-opens,java.base/java.lang=ALL-UNNAMED,--add-opens,java.base/java.lang.invoke=ALL-UNNAMED,--add-opens,java.prefs/java.util.prefs=ALL-UNNAMED,-XX:MaxMetaspaceSize=256m,-XX:+HeapDumpOnOutOfMemoryError,-Xmx512m,-Dfile.encoding=UTF-8,-Duser.country=US,-Duser.language=en,-Duser.variant]

  Looking for a different daemon...
The client will now receive all logging from the daemon (pid: 50280). The daemon log file: /Users/jared.bloomer/.gradle/daemon/5.0/daemon-50280.out.log
Starting 5th build in daemon [uptime: 17 mins 55.067 secs, performance: 99%]
Using 10 worker leases.
Starting Build
Settings evaluated using settings file '/Users/jared.bloomer/git/github.com/terraform-pipeline/settings.gradle'.
Projects loaded. Root project using build file '/Users/jared.bloomer/git/github.com/terraform-pipeline/build.gradle'.
Included projects: [root project 'terraform-pipeline']

> Configure project :
Evaluating root project 'terraform-pipeline' using build file '/Users/jared.bloomer/git/github.com/terraform-pipeline/build.gradle'.
All projects evaluated.
Selected primary task 'check' from project :
Tasks to be executed: [task ':codenarcMain', task ':codenarcTest', task ':compileJava', task ':compileGroovy', task ':processResources', task ':classes', task ':compileTestJava', task ':compileTestGroovy', task ':processTestResources', task ':testClasses', task ':test', task ':jacocoTestReport', task ':check']
:codenarcMain (Thread[Execution worker for ':',5,main]) started.

> Task :codenarcMain
Task ':codenarcMain' is not up-to-date because:
  Input property 'source' file /Users/jared.bloomer/git/github.com/terraform-pipeline/src/BuildStage.groovy has changed.
Loaded properties file in 4ms; 362 rules
Loading ruleset from [file:/Users/jared.bloomer/git/github.com/terraform-pipeline/config/codenarc/codenarc.xml]
Loading ruleset from [rulesets/groovyism.xml]
Loading ruleset from [rulesets/basic.xml]
Loading ruleset from [rulesets/braces.xml]
Loading ruleset from [rulesets/imports.xml]
Loading ruleset from [rulesets/formatting.xml]
RuleSet configuration properties file [codenarc.properties] not found.
Analysis time=370ms
No custom message bundle found for [codenarc-messages]. Using default messages.
Report file [/Users/jared.bloomer/git/github.com/terraform-pipeline/build/reports/codenarc/main.html] created.
[ant:codenarc] CodeNarc completed: (p1=0; p2=0; p3=0) 648ms
:codenarcMain (Thread[Execution worker for ':',5,main]) completed. Took 1.062 secs.
:codenarcTest (Thread[Execution worker for ':',5,main]) started.

> Task :codenarcTest UP-TO-DATE
Skipping task ':codenarcTest' as it is up-to-date.
:codenarcTest (Thread[Execution worker for ':',5,main]) completed. Took 0.001 secs.
:compileJava (Thread[Execution worker for ':',5,main]) started.

> Task :compileJava NO-SOURCE
file or directory '/Users/jared.bloomer/git/github.com/terraform-pipeline/src/main/java', not found
Skipping task ':compileJava' as it has no source files and no previous output files.
:compileJava (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:compileGroovy (Thread[Execution worker for ':',5,main]) started.
This JVM does not support getting OS memory, so no OS memory status updates will be broadcast
Initialized native services in: /Users/jared.bloomer/.gradle/native

> Task :compileGroovy
Task ':compileGroovy' is not up-to-date because:
  Task has failed previously.
Starting process 'Gradle Worker Daemon 3'. Working directory: /Users/jared.bloomer/.gradle/workers Command: /opt/homebrew/Cellar/openjdk@11/11.0.20.1/libexec/openjdk.jdk/Contents/Home/bin/java --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED @/private/var/folders/vs/v_tzptl970j59nq31x397vbr0000gq/T/gradle-worker-classpath13177837337760146237txt -Xmx512m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Worker Daemon 3'
Successfully started process 'Gradle Worker Daemon 3'
Started Gradle worker daemon (0.234 secs) with fork options DaemonForkOptions{executable=/opt/homebrew/Cellar/openjdk@11/11.0.20.1/libexec/openjdk.jdk/Contents/Home/bin/java, minHeapSize=null, maxHeapSize=null, jvmArgs=[--add-opens, java.base/java.lang=ALL-UNNAMED, --add-opens, java.base/java.lang.invoke=ALL-UNNAMED, --add-opens, java.prefs/java.util.prefs=ALL-UNNAMED], classpath=[/Users/jared.bloomer/.gradle/caches/modules-2/files-2.1/org.codehaus.groovy/groovy-all/2.4.12/760afc568cbd94c09d78f801ce51aed1326710af/groovy-all-2.4.12.jar, /Users/jared.bloomer/.gradle/wrapper/dists/gradle-5.0-bin/pu5208521seraqlersebvqk/gradle-5.0/lib/ant-1.9.13.jar, /Users/jared.bloomer/.gradle/wrapper/dists/gradle-5.0-bin/pu5208521seraqlersebvqk/gradle-5.0/lib/ant-launcher-1.9.13.jar], keepAliveMode=SESSION}.
:compileGroovy (Thread[Execution worker for ':',5,main]) completed. Took 1.25 secs.
:processResources (Thread[Execution worker for ':',5,main]) started.

> Task :processResources NO-SOURCE
file or directory '/Users/jared.bloomer/git/github.com/terraform-pipeline/src/main/resources', not found
Skipping task ':processResources' as it has no source files and no previous output files.
:processResources (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:classes (Thread[Execution worker for ':',5,main]) started.

> Task :classes
Skipping task ':classes' as it has no actions.
:classes (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:compileTestJava (Thread[Execution worker for ':',5,main]) started.

> Task :compileTestJava NO-SOURCE
file or directory '/Users/jared.bloomer/git/github.com/terraform-pipeline/src/test/java', not found
Skipping task ':compileTestJava' as it has no source files and no previous output files.
:compileTestJava (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:compileTestGroovy (Thread[Execution worker for ':',5,main]) started.

> Task :compileTestGroovy
Task ':compileTestGroovy' is not up-to-date because:
  No history is available.
:compileTestGroovy (Thread[Execution worker for ':',5,main]) completed. Took 2.283 secs.
:processTestResources (Thread[Execution worker for ':',5,main]) started.

> Task :processTestResources NO-SOURCE
file or directory '/Users/jared.bloomer/git/github.com/terraform-pipeline/src/test/resources', not found
Skipping task ':processTestResources' as it has no source files and no previous output files.
:processTestResources (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:testClasses (Thread[Execution worker for ':',5,main]) started.

> Task :testClasses
Skipping task ':testClasses' as it has no actions.
:testClasses (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.
:test (Thread[Execution worker for ':',5,main]) started.
Gradle Test Executor 4 started executing tests.

> Task :test
Task ':test' is not up-to-date because:
  No history is available.
Starting process 'Gradle Test Executor 4'. Working directory: /Users/jared.bloomer/git/github.com/terraform-pipeline Command: /opt/homebrew/Cellar/openjdk@11/11.0.20.1/libexec/openjdk.jdk/Contents/Home/bin/java -Dorg.gradle.native=false -javaagent:build/tmp/expandedArchives/org.jacoco.agent-0.8.2.jar_2aca8b620b19ecd063f63feff8caaa38/jacocoagent.jar=destfile=build/jacoco/test.exec,append=true,inclnolocationclasses=false,dumponexit=true,output=file,jmx=false @/private/var/folders/vs/v_tzptl970j59nq31x397vbr0000gq/T/gradle-worker-classpath16353838387270912434txt -Xmx512m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -ea worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Test Executor 4'
Successfully started process 'Gradle Test Executor 4'
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/Users/jared.bloomer/.gradle/caches/modules-2/files-2.1/org.codehaus.groovy/groovy-all/2.4.12/760afc568cbd94c09d78f801ce51aed1326710af/groovy-all-2.4.12.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

PassPlanFilePluginTest > PassPlanFilePluginTest$StashPlan.runsStashPlan() STANDARD_OUT
    MockWorkflowScript.echo Stashing tfplan-dev file
    MockWorkflowScript.dir(./)
    MockWorkflowScript.stash([name:tfplan-dev, includes:tfplan-dev])

PassPlanFilePluginTest > PassPlanFilePluginTest$UnstashPlan.runsUnstashPlan() STANDARD_OUT
    MockWorkflowScript.echo Unstashing tfplan-dev file
    MockWorkflowScript.dir(./)
    MockWorkflowScript.unstash(tfplan-dev)

TerraformImportPluginTest > TerraformImportPluginTest$RunTerraformImport.callsImportIfResource() STANDARD_OUT
    MockWorkflowScript.echo Running 'terraform import bar foo'. TerraformImportPlugin is enabled.
    MockWorkflowScript.sh: terraform import bar foo

TerraformPluginTest > TerraformPluginTest$CheckVersion.doesNotError() STANDARD_OUT
    MockWorkflowScript.ApplyJenkinsfileClosure
    MockWorkflowScript.node { }
    MockWorkflowScript.deleteDir
    MockWorkflowScript.checkout(null)

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString.includesTerraformFormatCommand() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithCheck.doesNotAddCheckOptionWhenFalse() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithCheck.addsCheckOptionByDefault() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithCheck$WithPatternOverride.usesThePatternWhenCheckIsFalse() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithCheck$WithPatternOverride.usesThePatternWhenCheckIsTrue() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithRecursive.doesNothingByDefaultUnsupportedByTerraformm11() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithDiff.doesNotAddDiffOptionWhenFalse() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithDiff.addsDiffOptionByDefault() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithDiff$WithPatternOverride.usesThePatternWhenCheckIsFalse() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

TerraformFormatCommandTest > TerraformFormatCommandTest$ToString$WithDiff$WithPatternOverride.usesThePatternWhenCheckIsTrue() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option

BuildWithParametersPluginTest > BuildWithParametersPluginTest$AddParameterToFirstStageOnly$WithParameters.addParametersOnlyOnceAfterMultipleCalls() STANDARD_OUT
    MockWorkflowScript.parameters: [myparams]
    MockWorkflowScript.properties: [null]

BuildWithParametersPluginTest > BuildWithParametersPluginTest$AddParameterToFirstStageOnly$WithParameters.addsTheParameters() STANDARD_OUT
    MockWorkflowScript.parameters: [myparams]
    MockWorkflowScript.properties: [null]

BuildWithParametersPluginTest > BuildWithParametersPluginTest$AddParameterToFirstStageOnly$WithParameters.runsTheInnerClosure() STANDARD_OUT
    MockWorkflowScript.parameters: []
    MockWorkflowScript.properties: [null]

AnsiColorPluginTest > AnsiColorPluginTest$AddColor.executesTheInnerClosure() STANDARD_OUT
    MockWorkflowScript.ansiColor(xterm)

AnsiColorPluginTest > AnsiColorPluginTest$AddColor.callsAnsiColorWithXTermArgument() STANDARD_OUT
    MockWorkflowScript.ansiColor(xterm)

S3BackendPluginTest > S3BackendPluginTest$Apply.addsDynamoDbTableAsBackendParameter() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket
    No MYENV_S3_BACKEND_BUCKET found either.
    No S3_BACKEND_REGION found - checking for environment-specific region
    MYENV_S3_BACKEND_DYNAMO_TABLE_LOCK is deprecated - please use MYENV_S3_BACKEND_DYNAMODB_TABLE instead
    No S3 backend bucket found
    No S3 backend region found
    No S3 backend encrypt found
    No S3 backend kms_key_id found

S3BackendPluginTest > S3BackendPluginTest$Apply.addsEnvironmentSpecificKeyAsBackendParameter() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket
    No MYENV_S3_BACKEND_BUCKET found either.
    No S3_BACKEND_REGION found - checking for environment-specific region
    No S3 backend bucket found
    No S3 backend region found
    No S3 backend dynamodb_table found
    No S3 backend encrypt found
    No S3 backend kms_key_id found

S3BackendPluginTest > S3BackendPluginTest$Apply.isAddedAndUsesCustomizedPatternFolderKeyAsBackendParameter() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket
    No MYENV_S3_BACKEND_BUCKET found either.
    No S3_BACKEND_REGION found - checking for environment-specific region
    No S3 backend bucket found
    No S3 backend region found
    No S3 backend dynamodb_table found
    No S3 backend encrypt found
    No S3 backend kms_key_id found

S3BackendPluginTest > S3BackendPluginTest$Apply.addsBucketRegionUsingPreDefinedEnvironmentVariableAsBackendParameter() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket
    No MYENV_S3_BACKEND_BUCKET found either.
    No S3_BACKEND_REGION found - checking for environment-specific region
    WARNING: DEFAULT_S3_BACKEND_REGION is deprecated, please use S3_BACKEND_REGION or MYENV_S3_BACKEND_REGION
    No S3 backend bucket found
    No S3 backend dynamodb_table found
    No S3 backend encrypt found
    No S3 backend kms_key_id found

S3BackendPluginTest > S3BackendPluginTest$Apply.skipsDynamoDbTableAsBackendParameterWhenNoneSpecified() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket
    No MYENV_S3_BACKEND_BUCKET found either.
    No S3_BACKEND_REGION found - checking for environment-specific region
    No S3 backend bucket found
    No S3 backend region found
    No S3 backend dynamodb_table found
    No S3 backend encrypt found
    No S3 backend kms_key_id found

S3BackendPluginTest > S3BackendPluginTest$Apply.addsBucketPreDefinedByEnvironmentAsBackendParameter() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket
    No S3_BACKEND_REGION found - checking for environment-specific region
    No S3 backend region found
    No S3 backend dynamodb_table found
    No S3 backend encrypt found
    No S3 backend kms_key_id found

S3BackendPluginTest > S3BackendPluginTest$GetBackend.shouldReturnTheValueOfTheEnvironmentSpecificS3BackendBucket() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket

S3BackendPluginTest > S3BackendPluginTest$GetBackend.shouldReturnTheValueOfTheEnvironmentSpecificS3BackendBucketCaseInsensitive() STANDARD_OUT
    No S3_BACKEND_BUCKET found - checking for environment-specific bucket

S3BackendPluginTest > S3BackendPluginTest$GetRegion.shouldReturnTheValueOfEnvironmentSpecificS3BackendRegionCaseInsensitive() STANDARD_OUT
    No S3_BACKEND_REGION found - checking for environment-specific region

S3BackendPluginTest > S3BackendPluginTest$GetRegion.shouldReturnTheValueOfEnvironmentSpecificS3BackendRegion() STANDARD_OUT
    No S3_BACKEND_REGION found - checking for environment-specific region

S3BackendPluginTest > S3BackendPluginTest$GetRegion.shouldReturnTheValueOfDefaultS3BackendRegion() STANDARD_OUT
    No S3_BACKEND_REGION found - checking for environment-specific region
    WARNING: DEFAULT_S3_BACKEND_REGION is deprecated, please use S3_BACKEND_REGION or MYENV_S3_BACKEND_REGION

S3BackendPluginTest > S3BackendPluginTest$GetRegion.shouldPreferEnvironmentSpecificRegionOverDeprecatedDefaultS3BackendRegion() STANDARD_OUT
    No S3_BACKEND_REGION found - checking for environment-specific region

S3BackendPluginTest > S3BackendPluginTest$GetDynamoTable.shouldReturnDeprecatedS3BackendDynamoTableLockValue() STANDARD_OUT
    MYENV_S3_BACKEND_DYNAMO_TABLE_LOCK is deprecated - please use MYENV_S3_BACKEND_DYNAMODB_TABLE instead

ValidateFormatPluginTest > ValidateFormatPluginTest$FormatClosure.runsTheGivenInnerClosure() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option
    MockWorkflowScript.sh: terraform fmt

ValidateFormatPluginTest > ValidateFormatPluginTest$FormatClosure.runsTerraformFormatCommandInAShell() STANDARD_OUT
    recursive is default in Terraform 0.11.x  - this is an unsupported option
    MockWorkflowScript.sh: terraform fmt

CredentialsPluginTest > CredentialsPluginTest$AddBuildCredentials.runsTheInnerClosure() STANDARD_OUT
    MockworkflowScript.withCredentials([])

CredentialsPluginTest > CredentialsPluginTest$AddBuildCredentials.callsWithCredentialsOnWorkflowScript() STANDARD_OUT
    MockworkflowScript.withCredentials([])

AwssumePluginTest > AwssumePluginTest$Apply$WithoutRoleProvided.skipsAwssumeForTerraformApply() STANDARD_OUT
    No AWS_ROLE_ARN is set, so awssume will not be used for terraform in the myEnv environment.

AwssumePluginTest > AwssumePluginTest$Apply$WithoutRoleProvided.skipsAwssumeForTerraformInit() STANDARD_OUT
    No AWS_ROLE_ARN is set, so awssume will not be used for terraform in the myEnv environment.

AwssumePluginTest > AwssumePluginTest$Apply$WithoutRoleProvided.skipsAwssumeForTerraformPlan() STANDARD_OUT
    No AWS_ROLE_ARN is set, so awssume will not be used for terraform in the myEnv environment.

GithubPRPlanPluginTest > GithubPRPlanPluginTest$AddComment$AndNotPullRequest.throwsErrorWhenInnerClosureFails() STANDARD_OUT
    MockWorkflowScript.echo terraform plan failed:
    MockWorkflowScript.sh: cat plan.err

GithubPRPlanPluginTest > GithubPRPlanPluginTest$AddComment$AndPullRequest.throwsErrorWhenInnerClosureFails() STANDARD_OUT
    MockWorkflowScript.echo terraform plan failed:
    MockWorkflowScript.sh: cat plan.err

GithubPRPlanPluginTest > GithubPRPlanPluginTest$PostPullRequestComment$doesNotBlowUp.forHttp1_1() STANDARD_OUT
    MockWorkflowScript.echo Creating comment in GitHub
    MockWorkflowScript.writeFile: [file:/MockWorkflowScript/currentDir/body.txt, text:{"body":"myPrComment"}]
    MockWorkflowScript.echo Created comment someId - some_url

TerraformEnvironmentStageTest > TerraformEnvironmentStageTest$PipelineConfigurations.doesNotBlowUpWhenRunningClosure() STANDARD_OUT
    MockWorkflowScript.node(foo)
    MockWorkflowScript.deleteDir
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.withEnv([TF_VAR_environment=foo])
    MockWorkflowScript.stage(plan-foo)
    MockWorkflowScript.sh: terraform init -input=false
    MockWorkflowScript.sh: terraform plan -input=false
    Current branch is null - you're probably using a single-branch job which doesn't make your branch name available.  Assume that apply should be enabled.
    MockWorkflowScript.stage(confirm-foo)
    MockWorkflowScript.timeout([time:15, unit:MINUTES])
    MockWorkflowScript.input([message:DANGER! Your foo environment will be IMMEDIATELY DESTROYED via "terraform destroy".  Review your plan to see all the resources that will be destroyed, and confirm. YOU CANNOT UNDO THIS., ok:Run terraform DESTROY now, submitterParameter:approver])
    MockWorkflowScript.echo Approved
    Current branch is null - you're probably using a single-branch job which doesn't make your branch name available.  Assume that apply should be enabled.
    MockWorkflowScript.stage(apply-foo)
    MockWorkflowScript.sh: terraform init -input=false
    MockWorkflowScript.sh: terraform apply -input=false -auto-approve

FlywayCommandTest > FlywayCommandTest$WithAdditionalParameter.isFluent() STANDARD_OUT
    withAdditionalParameter: -someParam=someValue, [-someParam=someValue]

FlywayCommandTest > FlywayCommandTest$ToString$WithAdditionalParameters.addsMultipleAdditionalParameters() STANDARD_OUT
    withAdditionalParameter: -param1=value1, [-param1=value1]
    withAdditionalParameter: -param2=value2, [-param1=value1, -param2=value2]

FlywayCommandTest > FlywayCommandTest$ToString$WithAdditionalParameters.addsTheAdditionalParameter() STANDARD_OUT
    withAdditionalParameter: -someParam=someValue, [-someParam=someValue]

TerraformValidateStageTest > TerraformValidateStageTest$PipelineConfiguration.justExerciseClosureNoAssertions() STANDARD_OUT
    MockWorkflowScript.node(null)
    MockWorkflowScript.deleteDir
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.stage(validate)
    MockWorkflowScript.sh: terraform validate

TerraformValidateStageTest > TerraformValidateStageTest$Build.justExerciseNoAssertions() STANDARD_OUT
    MockWorkflowScript.ApplyJenkinsfileClosure
    MockWorkflowScript.node(null)
    MockWorkflowScript.deleteDir
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.stage(validate)
    MockWorkflowScript.sh: terraform validate

ConditionalApplyPluginTest > ConditionalApplyPluginTest$ShouldApply.returnsTrueForMainByDefault() STANDARD_OUT
    Current branch 'main' matches expected branches '[main, master]', stage branch-condition is met and will run.

ConditionalApplyPluginTest > ConditionalApplyPluginTest$ShouldApply.returnsTrueWhenBranchIsUnknown() STANDARD_OUT
    Current branch is null - you're probably using a single-branch job which doesn't make your branch name available.  Assume that apply should be enabled.

ConditionalApplyPluginTest > ConditionalApplyPluginTest$ShouldApply$WithApplyOnBranchEnabled.returnsTrueForFirstConfiguredBranch() STANDARD_OUT
    Current branch 'qa' matches expected branches '[qa, someOtherBranch]', stage branch-condition is met and will run.

ConditionalApplyPluginTest > ConditionalApplyPluginTest$ShouldApply$WithApplyOnBranchEnabled.returnsTrueForOtherConfiguredBranches() STANDARD_OUT
    Current branch 'someOtherBranch' matches expected branches '[qa, someOtherBranch]', stage branch-condition is met and will run.

ConditionalApplyPluginTest > ConditionalApplyPluginTest$ShouldApply$WithApplyOnEnvironmentEnabled$OnMainBranch.returnsTrueForOtherEnvironments() STANDARD_OUT
    Current branch 'main' matches expected branches '[main, master]', stage branch-condition is met and will run.

RegressionStageTest > RegressionStageTest$AutomationRepo.automationRepoAndAppRepoSpecifiedSuccessfullyCallApply() STANDARD_OUT
    MockWorkflowScript.ApplyJenkinsfileClosure
    MockWorkflowScript.node(null)
    MockWorkflowScript.stage(test)
    MockWorkflowScript.dir(someRepo)
    MockWorkflowScript.resolveScm([source:[$class:GitSCMSource, remote:git:someHost:someUser/someRepo.git, traits:[[$class:jenkins.plugins.git.traits.BranchDiscoveryTrait], [$class:LocalBranchTrait]]], targets:[null, main]])
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.dir(someOtherRepo)
    MockWorkflowScript.resolveScm([source:[$class:GitSCMSource, remote:git:someHost:someUser/someOtherRepo.git, traits:[[$class:jenkins.plugins.git.traits.BranchDiscoveryTrait], [$class:LocalBranchTrait]]], targets:[null, main]])
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.sh: ./bin/test.sh

RegressionStageTest > RegressionStageTest$AutomationRepo.automationRepoSpecifiedSuccessfullyCallApply() STANDARD_OUT
    MockWorkflowScript.ApplyJenkinsfileClosure
    MockWorkflowScript.node(null)
    MockWorkflowScript.stage(test)
    MockWorkflowScript.resolveScm([source:[$class:GitSCMSource, remote:git:someHost:someUser/someRepo.git, traits:[[$class:jenkins.plugins.git.traits.BranchDiscoveryTrait], [$class:LocalBranchTrait]]], targets:[null, main]])
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.sh: ./bin/test.sh

RegressionStageTest > RegressionStageTest$AutomationRepo.noAutomationRepoSpecifiedSuccessfullyCallApply() STANDARD_OUT
    MockWorkflowScript.ApplyJenkinsfileClosure
    MockWorkflowScript.node(null)
    MockWorkflowScript.stage(test)
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.sh: ./bin/test.sh

RegressionStageTest > RegressionStageTest$AutomationRepo.automationRepoAndAppRepoWithChangeDirectorySpecifiedSuccessfullyCallApply() STANDARD_OUT
    MockWorkflowScript.ApplyJenkinsfileClosure
    MockWorkflowScript.node(null)
    MockWorkflowScript.stage(test)
    MockWorkflowScript.dir(someRepo)
    MockWorkflowScript.resolveScm([source:[$class:GitSCMSource, remote:git:someHost:someUser/someRepo.git, traits:[[$class:jenkins.plugins.git.traits.BranchDiscoveryTrait], [$class:LocalBranchTrait]]], targets:[null, main]])
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.dir(someOtherRepo)
    MockWorkflowScript.resolveScm([source:[$class:GitSCMSource, remote:git:someHost:someUser/someOtherRepo.git, traits:[[$class:jenkins.plugins.git.traits.BranchDiscoveryTrait], [$class:LocalBranchTrait]]], targets:[null, main]])
    MockWorkflowScript.checkout(null)
    MockWorkflowScript.dir(someDir)
    MockWorkflowScript.sh: ./bin/test.sh

TerraformPluginVersion12Test > TerraformPluginVersion12Test$AddInitBefore.runsTheInnerClosure() STANDARD_OUT
    MockWorkflowScript.sh: terraform init -input=false -backend=false

TerraformStartDirectoryPluginTest > TerraformStartDirectoryPluginTest$AddDirectory$WithDirectory.useDirectory() STANDARD_OUT
    MockWorkflowScript.dir(./customDirectory/)

TerraformStartDirectoryPluginTest > TerraformStartDirectoryPluginTest$AddDirectory$WithDirectory.runsTheNestedClosure() STANDARD_OUT
    MockWorkflowScript.dir(./customDirectory/)

BuildStageTest > BuildStageTest$Build.buildsWithoutError() STANDARD_OUT
    MockWorkflowScript.ApplyJenkinsfileClosure

ParameterStoreBuildWrapperPluginTest > ParameterStoreBuildWrapperPluginTest$withGlobalParameter.addGlobalParameterWithNoOptions() STANDARD_OUT
    class ParameterStoreBuildWrapperPlugin

FlywayMigrationPluginTest > FlywayMigrationPluginTest$FlywayInfoClosure.setsTheListOfOptionalEnvironmentVariables() STANDARD_OUT
    MockWorkflowScript.withEnv([KEY=value])
    MockWorkflowScript.sh: set +x
    set -o pipefail
    flyway info| tee flyway_output.txt
    set -x

FlywayMigrationPluginTest > FlywayMigrationPluginTest$FlywayInfoClosure.runsTheNestedClosure() STANDARD_OUT
    MockWorkflowScript.withEnv([])
    MockWorkflowScript.sh: set +x
    set -o pipefail
    flyway info| tee flyway_output.txt
    set -x

FlywayMigrationPluginTest > FlywayMigrationPluginTest$FlywayMigrateClosure.doesNotRunConfirmMigrationIfConfirmBeforeApplyAndDoesNotHavePendingMigration() STANDARD_OUT
    MockWorkflowScript.withEnv([])
    MockWorkflowScript.sh: set +x
    set -o pipefail
    flyway migrate| tee flyway_output.txt
    set -x

FlywayMigrationPluginTest > FlywayMigrationPluginTest$FlywayMigrateClosure.doesNotRunConfirmMigrationIfNotConfirmBeforeApplyAndHasPendingMigration() STANDARD_OUT
    MockWorkflowScript.withEnv([])
    MockWorkflowScript.sh: set +x
    flyway migrate
    set -x

FlywayMigrationPluginTest > FlywayMigrationPluginTest$FlywayMigrateClosure.runsConfirmMigrationIfConfirmBeforeApplyAndHasPendingMigration() STANDARD_OUT
    MockWorkflowScript.timeout([time:1, unit:MINUTES])
    MockWorkflowScript.input(One or more pending migrations will be applied immediately if you continue - please review the flyway info output.  Are you sure you want to continue?)
    MockWorkflowScript.withEnv([])
    MockWorkflowScript.sh: set +x
    set -o pipefail
    flyway migrate| tee flyway_output.txt
    set -x

FlywayMigrationPluginTest > FlywayMigrationPluginTest$FlywayMigrateClosure.setsTheListOfOptionalEnvironmentVariables() STANDARD_OUT
    MockWorkflowScript.sh: [script:set +e; grep Pending flyway_output.txt > /dev/null; if [ $? -eq 0 ]; then echo true; else echo false; fi, returnStdout:true]
    MockWorkflowScript.withEnv([KEY=value])
    MockWorkflowScript.sh: set +x
    set -o pipefail
    flyway migrate| tee flyway_output.txt
    set -x

FlywayMigrationPluginTest > FlywayMigrationPluginTest$FlywayMigrateClosure.runsTheNestedClosure() STANDARD_OUT
    MockWorkflowScript.sh: [script:set +e; grep Pending flyway_output.txt > /dev/null; if [ $? -eq 0 ]; then echo true; else echo false; fi, returnStdout:true]
    MockWorkflowScript.withEnv([])
    MockWorkflowScript.sh: set +x
    set -o pipefail
    flyway migrate| tee flyway_output.txt
    set -x

Gradle Test Executor 4 finished executing tests.

> Task :test
Finished generating test XML results (0.035 secs) into: /Users/jared.bloomer/git/github.com/terraform-pipeline/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.069 secs) into: /Users/jared.bloomer/git/github.com/terraform-pipeline/build/reports/tests/test
:test (Thread[Execution worker for ':',5,main]) completed. Took 8.723 secs.
:jacocoTestReport (Thread[Execution worker for ':',5,main]) started.

> Task :jacocoTestReport
Task ':jacocoTestReport' is not up-to-date because:
  No history is available.
[ant:jacocoReport] Loading execution data file /Users/jared.bloomer/git/github.com/terraform-pipeline/build/jacoco/test.exec
[ant:jacocoReport] Writing bundle 'terraform-pipeline' with 197 classes
:jacocoTestReport (Thread[Execution worker for ':',5,main]) completed. Took 1.338 secs.
:check (Thread[Execution worker for ':',5,main]) started.

> Task :check
Skipping task ':check' as it has no actions.
:check (Thread[Execution worker for ':',5,main]) completed. Took 0.0 secs.

BUILD SUCCESSFUL in 17s
6 actionable tasks: 5 executed, 1 up-to-date
Stopped 1 worker daemon(s).
```